### PR TITLE
fix ci by dropping error

### DIFF
--- a/pkg/tarball/write.go
+++ b/pkg/tarball/write.go
@@ -262,14 +262,8 @@ func (ctx *Context) WriteArchive(dst io.Writer, src fs.FS) error {
 	}
 
 	// get the uname and gname maps
-	usersFile, err := passwd.ReadUserFile(src, "etc/passwd")
-	if err != nil {
-		return fmt.Errorf("reading passwd file failed: %w", err)
-	}
-	groupsFile, err := passwd.ReadGroupFile(src, "etc/group")
-	if err != nil {
-		return fmt.Errorf("reading group file failed: %w", err)
-	}
+	usersFile, _ := passwd.ReadUserFile(src, "etc/passwd")
+	groupsFile, _ := passwd.ReadGroupFile(src, "etc/group")
 	users := map[int]string{}
 	groups := map[int]string{}
 	for _, u := range usersFile.Entries {


### PR DESCRIPTION
I foolishly added error handling to appease the linter in #2, [here](https://github.com/chainguard-dev/go-apk/pull/2/files#diff-a5917b2527ff7a9e5cd18a3d19c2cf551889282ece56c9fc1b0a9f1c895af854R265). And the linter doesn't even care! 🤦 