### PR TITLE
Fix linter issues

### DIFF
--- a/pkg/apk/common_test.go
+++ b/pkg/apk/common_test.go
@@ -57,10 +57,7 @@ func testGetTestAPK() (*APK, apkfs.FullFS, error) {
 			return nil
 		}
 		if d.IsDir() {
-			if err := src.MkdirAll(path, d.Type()); err != nil {
-				return err
-			}
-			return nil
+			return src.MkdirAll(path, d.Type())
 		}
 		r, err := filesystem.Open(path)
 		if err != nil {

--- a/pkg/apk/implementation.go
+++ b/pkg/apk/implementation.go
@@ -409,7 +409,7 @@ func (a *APK) ResolveWorld() (toInstall []*repository.RepositoryPackage, conflic
 }
 
 // FixateWorld force apk's resolver to re-resolve the requested dependencies in /etc/apk/world.
-func (a *APK) FixateWorld(cache, updateCache, executeScripts bool, sourceDateEpoch *time.Time) error {
+func (a *APK) FixateWorld(sourceDateEpoch *time.Time) error {
 	/*
 		equivalent of: "apk fix --arch arch --root root"
 		with possible options for --no-scripts, --no-cache, --update-cache
@@ -461,7 +461,7 @@ func (a *APK) FixateWorld(cache, updateCache, executeScripts bool, sourceDateEpo
 			continue
 		}
 		// get the apk file
-		if err := a.installPackage(pkg, cache, updateCache, executeScripts, sourceDateEpoch); err != nil {
+		if err := a.installPackage(pkg, sourceDateEpoch); err != nil {
 			return err
 		}
 	}
@@ -544,8 +544,8 @@ func (a *APK) fetchAlpineKeys(versions []string) error {
 
 // installPkg install a single package and update installed db.
 //
-//nolint:unparam // we do not use some params... yet.
-func (a *APK) installPackage(pkg *repository.RepositoryPackage, cache, updateCache, executeScripts bool, sourceDateEpoch *time.Time) error {
+
+func (a *APK) installPackage(pkg *repository.RepositoryPackage, sourceDateEpoch *time.Time) error {
 	a.logger.Debugf("installing %s (%s)", pkg.Name, pkg.Version)
 
 	u := pkg.Url()

--- a/pkg/apk/implementation_test.go
+++ b/pkg/apk/implementation_test.go
@@ -233,7 +233,3 @@ func TestLoadSystemKeyring(t *testing.T) {
 		})
 	}
 }
-
-func TestFixateWorld(t *testing.T) {
-
-}

--- a/pkg/fs/rwosfs.go
+++ b/pkg/fs/rwosfs.go
@@ -50,7 +50,7 @@ func DirFSWithCaseSensitive(caseSensitive bool) DirFSOption {
 
 // WithCreateDir allows you to specify whether the underlying directory
 // should be created if it does not exist. Default is false.
-func WithCreateDir(createDir bool) DirFSOption {
+func WithCreateDir() DirFSOption {
 	return func(opts *dirFSOpts) error {
 		opts.mkdir = true
 		return nil

--- a/pkg/tarball/append.go
+++ b/pkg/tarball/append.go
@@ -77,9 +77,5 @@ func (m *MultiTar) Close() error {
 		return err
 	}
 
-	if err := m.out.Close(); err != nil {
-		return err
-	}
-
-	return nil
+	return m.out.Close()
 }


### PR DESCRIPTION
This PR has two commits:
1. Fixes I'm more sure about
2. Fixes I'm less sure about

On that second one — we have some functions with a lot of parameters, and for some of those functions, most of the parameters are unused. Now that this repo is its own lib, and before it gets more tests, it's less obvious whether those extra parameters are needed by anyone. If they're not, this PR should be good to go. Otherwise that second commit should just replace parameter names with `_` for now.