### PR TITLE
repositories file should end with newline

### DIFF
--- a/pkg/apk/implementation_test.go
+++ b/pkg/apk/implementation_test.go
@@ -112,7 +112,7 @@ func TestSetRepositories(t *testing.T) {
 	actual, err := src.ReadFile("etc/apk/repositories")
 	require.NoError(t, err)
 
-	expected := strings.Join(repos, "\n")
+	expected := strings.Join(repos, "\n") + "\n"
 	require.Equal(t, expected, string(actual), "unexpected content for etc/apk/repositories:\nexpected %s\nactual %s", expected, actual)
 }
 

--- a/pkg/apk/repo.go
+++ b/pkg/apk/repo.go
@@ -76,7 +76,7 @@ type repositoryPackage struct {
 func (a *APK) SetRepositories(repos []string) error {
 	a.logger.Infof("setting apk repositories")
 
-	data := strings.Join(repos, "\n")
+	data := strings.Join(repos, "\n") + "\n"
 
 	// #nosec G306 -- apk repositories must be publicly readable
 	if err := a.fs.WriteFile(filepath.Join("etc", "apk", "repositories"),


### PR DESCRIPTION
Fixes https://github.com/chainguard-dev/apko/issues/657