### PR TITLE
add xattrs support to fs

### DIFF
--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -39,6 +39,10 @@ type FullFS interface {
 	Remove(name string) error
 	Chmod(path string, perm fs.FileMode) error
 	Chown(path string, uid int, gid int) error
+	SetXattr(path string, attr string, data []byte) error
+	GetXattr(path string, attr string) ([]byte, error)
+	RemoveXattr(path string, attr string) error
+	ListXattrs(path string) (map[string][]byte, error)
 }
 
 // File is an interface for a file. It includes Read, Write, Close.

--- a/pkg/fs/rwosfs.go
+++ b/pkg/fs/rwosfs.go
@@ -510,6 +510,21 @@ func (f *dirFS) Mknod(name string, mode uint32, dev int) error {
 	return f.overrides.Mknod(name, mode, dev)
 }
 
+func (f *dirFS) SetXattr(path string, attr string, data []byte) error {
+	// the underlying filesystem might or might not support xattrs
+	// but we have info on every file in memory, so might as well store it there.
+	return f.overrides.SetXattr(path, attr, data)
+}
+func (f *dirFS) GetXattr(path string, attr string) ([]byte, error) {
+	return f.overrides.GetXattr(path, attr)
+}
+func (f *dirFS) RemoveXattr(path string, attr string) error {
+	return f.overrides.RemoveXattr(path, attr)
+}
+func (f *dirFS) ListXattrs(path string) (map[string][]byte, error) {
+	return f.overrides.ListXattrs(path)
+}
+
 // sanitize ensures that we never go beyond the root of the filesystem
 func (f *dirFS) sanitizePath(p string) (v string, err error) {
 	return sanitizePath(f.base, p)


### PR DESCRIPTION
First step in solving #599. This adds xattr support to `fs.FullFS` interface, as well as the two implementations.

It does not check for the various namespaces, as I didn't see much value in it here. Generally, that is something done at a higher level.

It does not yet use them when reading/writing tar streams. That will be next phase.\

Obviously includes unit tests