### PR TITLE
consistent ordering in filesystem, both memfs and dirfs, with tests

### DIFF
--- a/pkg/fs/memfs.go
+++ b/pkg/fs/memfs.go
@@ -23,6 +23,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -288,6 +289,10 @@ func (m *memFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	for name, node := range anode.children {
 		de = append(de, fs.FileInfoToDirEntry(node.fileInfo(name)))
 	}
+	// we need them in a consistent order, so sort them by filename, which is what os.ReadDir() does
+	sort.Slice(de, func(i, j int) bool {
+		return de[i].Name() < de[j].Name()
+	})
 	return de, nil
 }
 

--- a/pkg/fs/rwosfs.go
+++ b/pkg/fs/rwosfs.go
@@ -19,6 +19,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -396,6 +397,11 @@ func (f *dirFS) ReadDir(name string) ([]fs.DirEntry, error) {
 		}
 		dirEntries = append(dirEntries, &dirEntry{disk: f, mem: m})
 	}
+	// we need them in a consistent order
+	sort.Slice(dirEntries, func(i, j int) bool {
+		return dirEntries[i].Name() < dirEntries[j].Name()
+	})
+
 	return dirEntries, nil
 }
 func (f *dirFS) ReadFile(name string) ([]byte, error) {


### PR DESCRIPTION
We had been relying on `fs.WalkDir()` to sort the entries before passing them on. Which they do, but apparently not well enough. Either way, we should be consistent about the order of entries from `ReadDir()`.

I tested `apko` using this branch, running multiple times. All of the contents of the tar now are consistent: layer tgz, manifest.json, index.json, config.

E.g.:

```bash
$ sha256sum output1/*
1ee7dffd899ea0383d5ed25d5ddb9dccdaf7cc9c7f0c4f787f08e4484ecd9ae8  output1/1ee7dffd899ea0383d5ed25d5ddb9dccdaf7cc9c7f0c4f787f08e4484ecd9ae8.tar.gz
7988175e09e039d93adda821baa1946c7494c006910fae07d423eafe93f10fa9  output1/index.json
4d3ca09fdb4186f23ed4b5c7fd410dc36fdebb1175cc25617fdc27f5a9f4a55d  output1/manifest.json
9af1d962a8a087e1b260ca4dfc80e0a83b5487c375b36fefa59c5a5275a24ec2  output1/sha256:9af1d962a8a087e1b260ca4dfc80e0a83b5487c375b36fefa59c5a5275a24ec2
a00d6eff8b11f8e83e0dcc9903da842bdb357059909f2dc14512752d78d6eaa6  output1/sha256:a00d6eff8b11f8e83e0dcc9903da842bdb357059909f2dc14512752d78d6eaa6

$ output2/*
1ee7dffd899ea0383d5ed25d5ddb9dccdaf7cc9c7f0c4f787f08e4484ecd9ae8  output2/1ee7dffd899ea0383d5ed25d5ddb9dccdaf7cc9c7f0c4f787f08e4484ecd9ae8.tar.gz
7988175e09e039d93adda821baa1946c7494c006910fae07d423eafe93f10fa9  output2/index.json
4d3ca09fdb4186f23ed4b5c7fd410dc36fdebb1175cc25617fdc27f5a9f4a55d  output2/manifest.json
9af1d962a8a087e1b260ca4dfc80e0a83b5487c375b36fefa59c5a5275a24ec2  output2/sha256:9af1d962a8a087e1b260ca4dfc80e0a83b5487c375b36fefa59c5a5275a24ec2
a00d6eff8b11f8e83e0dcc9903da842bdb357059909f2dc14512752d78d6eaa6  output2/sha256:a00d6eff8b11f8e83e0dcc9903da842bdb357059909f2dc14512752d78d6eaa6
```