### PR TITLE
handle deadlock situation when MkdirAll through symlinks

### DIFF
--- a/pkg/fs/memfs.go
+++ b/pkg/fs/memfs.go
@@ -164,7 +164,6 @@ func (m *memFS) MkdirAll(path string, perm fs.FileMode) error {
 		}
 		var ok bool
 		anode.mu.Lock()
-		defer anode.mu.Unlock()
 		newnode, ok := anode.children[part]
 		if !ok {
 			newnode = &node{
@@ -178,6 +177,7 @@ func (m *memFS) MkdirAll(path string, perm fs.FileMode) error {
 			}
 			anode.children[part] = newnode
 		}
+		anode.mu.Unlock()
 		// what if it is a symlink?
 		if newnode.mode&os.ModeSymlink != 0 {
 			linkTarget := newnode.linkTarget

--- a/pkg/fs/memfs_test.go
+++ b/pkg/fs/memfs_test.go
@@ -350,6 +350,19 @@ func TestMemFSXattrs(t *testing.T) {
 	})
 }
 
+func TestMemFSSymlinkLoop(t *testing.T) {
+	var (
+		m   = NewMemFS()
+		err error
+	)
+	err = m.MkdirAll("/a/b/c", 0o755)
+	require.NoError(t, err)
+	err = m.Symlink("/a/b", "/a/link")
+	require.NoError(t, err)
+	err = m.MkdirAll("/a/link/q/c", 0o755)
+	require.NoError(t, err)
+}
+
 func TestMemFSConsistentOrdering(t *testing.T) {
 	var (
 		m = NewMemFS()


### PR DESCRIPTION
And, of course, a test for it. Before the fix, the test was stuck; after, it passes.