### PR TITLE
Drop `nil` error from `fmt.Errorf`

### DIFF
--- a/pkg/apk/repo.go
+++ b/pkg/apk/repo.go
@@ -344,7 +344,7 @@ func (p *PkgResolver) ResolvePackage(pkgName string) (pkgs []*repository.Reposit
 		// get the one that most matches what was requested
 		packages = filterPackages(pkgsWithVersions, withVersion(version, compare), withPreferPin(pin))
 		if len(packages) == 0 {
-			return nil, fmt.Errorf("could not find package %s in indexes: %w", pkgName, err)
+			return nil, fmt.Errorf("could not find package %s in indexes", pkgName)
 		}
 		sortPackages(packages, nil, name, nil, pin)
 	} else {


### PR DESCRIPTION
I saw this error and tracked it back to this line, which adds a `%w` for an uninitialized `err`:
```
installing apk packages: could not find package tzdata=2023c-r0 in indexes: %!w(<nil>)
```