### PR TITLE
Add tarball.WriteTar and tarball.WriteTargz

### DIFF
--- a/pkg/signature/sign.go
+++ b/pkg/signature/sign.go
@@ -18,6 +18,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"crypto/sha1" //nolint:gosec
 	"errors"
 	"fmt"
@@ -75,7 +76,7 @@ func SignIndex(logger logger.Logger, signingKey string, indexFile string) error 
 	logger.Printf("writing signed index to %s", indexFile)
 
 	var sigBuffer bytes.Buffer
-	if err := multitarctx.WriteArchive(&sigBuffer, sigFS); err != nil {
+	if err := multitarctx.WriteTargz(context.TODO(), &sigBuffer, sigFS); err != nil {
 		return fmt.Errorf("unable to write signature tarball: %w", err)
 	}
 

--- a/pkg/tarball/write_test.go
+++ b/pkg/tarball/write_test.go
@@ -3,6 +3,7 @@ package tarball
 import (
 	"archive/tar"
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/chainguard-dev/go-apk/pkg/fs"
@@ -28,7 +29,7 @@ func TestWriteTar(t *testing.T) {
 	require.NoError(t, err, "error setting xattr on %s", file)
 	ctx := Context{}
 	tw := tar.NewWriter(&buf)
-	err = ctx.writeTar(tw, m, nil, nil)
+	err = ctx.writeTar(context.Background(), tw, m, nil, nil)
 	require.NoError(t, err, "error writing tar")
 	err = tw.Close()
 	require.NoError(t, err, "error closing tar writer")


### PR DESCRIPTION
Gzipping before writing to the output makes it impossible for callers to control the gzip implementation, but more importantly it makes it impossible for callers to get access to the uncompressed tar stream, which is necessary for computing the DiffID for OCI layers.