### PR TITLE
fail if no repos are specified

### DIFF
--- a/pkg/apk/implementation_test.go
+++ b/pkg/apk/implementation_test.go
@@ -116,6 +116,20 @@ func TestSetRepositories(t *testing.T) {
 	require.Equal(t, expected, string(actual), "unexpected content for etc/apk/repositories:\nexpected %s\nactual %s", expected, actual)
 }
 
+func TestSetRepositories_Empty(t *testing.T) {
+	src := apkfs.NewMemFS()
+	apk, err := New(WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
+	require.NoError(t, err)
+	// for initialization
+
+	err = src.MkdirAll("etc/apk", 0o755)
+	require.NoError(t, err)
+
+	repos := []string{}
+	err = apk.SetRepositories(repos)
+	require.Error(t, err)
+}
+
 func TestInitKeyring(t *testing.T) {
 	src := apkfs.NewMemFS()
 	a, err := New(WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))

--- a/pkg/apk/repo.go
+++ b/pkg/apk/repo.go
@@ -76,6 +76,10 @@ type repositoryPackage struct {
 func (a *APK) SetRepositories(repos []string) error {
 	a.logger.Infof("setting apk repositories")
 
+	if len(repos) == 0 {
+		return fmt.Errorf("must provide at least one repository")
+	}
+
 	data := strings.Join(repos, "\n") + "\n"
 
 	// #nosec G306 -- apk repositories must be publicly readable


### PR DESCRIPTION
This should hopefully fail with a more helpful error message when repos are not set.

Otherwise the error we get is something like 

```
error getting package dependencies: could not find package, alias or a package that provides binutils in indexes
```

because `binutils` is specified in `packages` but there are no `repositories` specified to provide that package.