### PR TITLE
system-default cachedir needs apko-specific subdir

### DIFF
--- a/pkg/apk/options.go
+++ b/pkg/apk/options.go
@@ -17,6 +17,7 @@ package apk
 import (
 	"io"
 	"os"
+	"path/filepath"
 	"runtime"
 
 	apkfs "github.com/chainguard-dev/go-apk/pkg/fs"
@@ -95,6 +96,7 @@ func WithCache(cacheDir string) Option {
 			if err != nil {
 				return err
 			}
+			cacheDir = filepath.Join(cacheDir, "dev.chainguard.go-apk")
 		}
 		o.cache = &cache{dir: cacheDir}
 		return nil


### PR DESCRIPTION
When the user passes their preferred cache-dir, we should use that, which we do. The default cache dir, from [os.UserCacheDir()](https://pkg.go.dev/os#UserCacheDir), however, is generic, and is expected to have an app-specific subdir. This adds it.