### PR TITLE
add WithBaseDir option to tar context

### DIFF
--- a/pkg/tarball/tarball.go
+++ b/pkg/tarball/tarball.go
@@ -28,6 +28,7 @@ type Context struct {
 	OverrideGname   string
 	SkipClose       bool
 	UseChecksums    bool
+	BaseDir         string
 	overridePerms   map[string]tar.Header
 }
 
@@ -72,6 +73,14 @@ func WithOverridePerms(files []tar.Header) Option {
 			overrides[f.Name] = f
 		}
 		ctx.overridePerms = overrides
+		return nil
+	}
+}
+
+// WithBaseDir prefixes the contents of the tar stream with the given directory.
+func WithBaseDir(directory string) Option {
+	return func(ctx *Context) error {
+		ctx.BaseDir = directory
 		return nil
 	}
 }

--- a/pkg/tarball/write.go
+++ b/pkg/tarball/write.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"syscall"
 
 	gzip "golang.org/x/build/pargzip"
@@ -143,7 +144,7 @@ func (c *Context) writeTar(ctx context.Context, tw *tar.Writer, fsys fs.FS, user
 			header.Devminor = int64(minor)
 		}
 		// work around some weirdness, without this we wind up with just the basename
-		header.Name = path
+		header.Name = filepath.Join(c.BaseDir, path)
 
 		// zero out timestamps for reproducibility
 		header.AccessTime = c.SourceDateEpoch


### PR DESCRIPTION
Adds a `WithBaseDir` option to the tar context to allow building tarballs with more control over the archives root directory.

This is useful when the unarchive process isn't performed by the consumer, but the consumer still wants to adhere to some required directory structure (such as in `kontext`, where the archive is used to create a container layer unpacked at `/`)

This option is disabled by default.