### PR TITLE
add debug logging to show indexes and packages before installing

### DIFF
--- a/pkg/apk/repo.go
+++ b/pkg/apk/repo.go
@@ -35,6 +35,14 @@ type NamedIndex interface {
 	Source() string
 }
 
+func indexNames(indexes []NamedIndex) []string {
+	names := make([]string, len(indexes))
+	for i, idx := range indexes {
+		names[i] = idx.Source()
+	}
+	return names
+}
+
 type namedRepositoryWithIndex struct {
 	name string
 	repo *repository.RepositoryWithIndex


### PR DESCRIPTION
We sometimes have situations where two similar builds will have a different outcome. We find ourselves in a situation where it depends on the list of packages and their source that will be installed. We can reproduce it, but it it requires a lot of manual work (and some intelligent guesswork).

This removes a lot of that by logging (when debug only, of course), right before it starts to install, the list of repositories from which it will install, and the exact package names, versions _and sources_. This allows you to compare the _plan_ before it does the install, which will help debug failures.