### PR TITLE
handle preinstalled packages with filterPackages

### DIFF
--- a/pkg/apk/repo.go
+++ b/pkg/apk/repo.go
@@ -471,7 +471,11 @@ func (p *PkgResolver) getPackageDependencies(pkg *repository.RepositoryPackage, 
 		if ok {
 			// pkgsWithVersions contains a map of all versions of the package
 			// get the one that most matches what was requested
-			pkgs := filterPackages(depPkgWithVersions, withVersion(version, compare), withAllowPin(allowPin))
+			pkgs := filterPackages(depPkgWithVersions,
+				withVersion(version, compare),
+				withAllowPin(allowPin),
+				withInstalledPackage(existing[name]),
+			)
 			if len(pkgs) == 0 {
 				return nil, nil, fmt.Errorf("could not find package %s in indexes", dep)
 			}

--- a/pkg/apk/repo_test.go
+++ b/pkg/apk/repo_test.go
@@ -630,5 +630,14 @@ func testNamedPackageFromPackages(pkgs []*repository.RepositoryPackage) (named [
 }
 
 func testNamedPackageFromVersionAndPin(version, pin string) *repositoryPackage {
-	return &repositoryPackage{RepositoryPackage: &repository.RepositoryPackage{Package: &repository.Package{Version: version}}, pinnedName: pin}
+	rp := repository.NewRepositoryPackage(
+		&repository.Package{Version: version},
+		&repository.RepositoryWithIndex{
+			Repository: &repository.Repository{Uri: "local"},
+		},
+	)
+	return &repositoryPackage{
+		RepositoryPackage: rp,
+		pinnedName:        pin,
+	}
 }


### PR DESCRIPTION
Consider the following:

```yaml
packages:
- first@local
- second
```

where `second` has a dependency on `first`, with no version constraint. In addition, `php` in `local` repo has version `v1.0.0`, and upstream has `v2.0.0`.

* If we didn't have `@local`, this should resolve to a single install of `first v2.0.0` from upstream, as the highest
* with the `@local` constraint, `first v1.0.0` should be installed, and when `second` is resolved, with its dependency on `first`, it should recognize that `first` already is installed and use it.

Unfortunately, that is not the case.

It _does_ install `first v1.0.0`, but then, when resolving the dependencies of `second`, it removes `v1.0.0` during `filterPackages()`, because `first v1.0.0` came from a pinned repository `@local`, and `second` does not have that pin.

This is incorrect.

`second` _on its own_ cannot pull from `@local` without the pin; but if it already is installed due to a higher-level dependency, i.e. the explicitly declared `first@local` package, then it can and should consider it as it is _already installed_.

As found by @erikaheidi and confirmed by @kaniin.

Added tests for this and other similar situations.