### PR TITLE
Use retryablehttp as the default client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/chainguard-dev/go-apk
 go 1.20
 
 require (
+	github.com/hashicorp/go-retryablehttp v0.7.4
 	github.com/psanford/memfs v0.0.0-20230130182539-4dbf7e3e865e
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.4
@@ -17,6 +18,7 @@ require (
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,12 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-retryablehttp v0.7.4 h1:ZQgVdpTdAL7WpMIwLzCfbalOcSUdkDZnpUv3/+BxzFA=
+github.com/hashicorp/go-retryablehttp v0.7.4/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/psanford/memfs v0.0.0-20230130182539-4dbf7e3e865e h1:51xcRlSMBU5rhM9KahnJGfEsBPVPz3182TgFRowA8yY=
@@ -14,6 +20,7 @@ github.com/psanford/memfs v0.0.0-20230130182539-4dbf7e3e865e/go.mod h1:tcaRap0jS
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=

--- a/pkg/apk/implementation.go
+++ b/pkg/apk/implementation.go
@@ -37,6 +37,7 @@ import (
 
 	apkfs "github.com/chainguard-dev/go-apk/pkg/fs"
 	logger "github.com/chainguard-dev/go-apk/pkg/logger"
+	"github.com/hashicorp/go-retryablehttp"
 )
 
 type APK struct {
@@ -363,7 +364,7 @@ func (a *APK) InitKeyring(ctx context.Context, keyFiles, extraKeyFiles []string)
 			case "https": //nolint:goconst
 				client := a.client
 				if client == nil {
-					client = &http.Client{}
+					client = retryablehttp.NewClient().StandardClient()
 				}
 				req, err := http.NewRequestWithContext(ctx, http.MethodGet, asURL.String(), nil)
 				if err != nil {
@@ -495,7 +496,7 @@ func (a *APK) fetchAlpineKeys(ctx context.Context, alpineVersions []string) erro
 	u := alpineReleasesURL
 	client := a.client
 	if client == nil {
-		client = &http.Client{}
+		client = retryablehttp.NewClient().StandardClient()
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
@@ -594,7 +595,7 @@ func (a *APK) installPackage(ctx context.Context, pkg *repository.RepositoryPack
 	case "https":
 		client := a.client
 		if client == nil {
-			client = &http.Client{}
+			client = retryablehttp.NewClient().StandardClient()
 		}
 		if a.cache != nil {
 			client = a.cache.client(client, false)

--- a/pkg/apk/index.go
+++ b/pkg/apk/index.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 
 	sign "github.com/chainguard-dev/go-apk/pkg/signature"
+	"github.com/hashicorp/go-retryablehttp"
 	"gitlab.alpinelinux.org/alpine/go/repository"
 	"go.lsp.dev/uri"
 )
@@ -99,7 +100,7 @@ func GetRepositoryIndexes(ctx context.Context, repos []string, keys map[string][
 		case "https":
 			client := opts.httpClient
 			if client == nil {
-				client = &http.Client{}
+				client = retryablehttp.NewClient().StandardClient()
 			}
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, asURL.String(), nil)
 			if err != nil {

--- a/pkg/apk/repo.go
+++ b/pkg/apk/repo.go
@@ -19,11 +19,11 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/http"
 	"path/filepath"
 	"sort"
 	"strings"
 
+	"github.com/hashicorp/go-retryablehttp"
 	"gitlab.alpinelinux.org/alpine/go/repository"
 )
 
@@ -154,7 +154,7 @@ func (a *APK) getRepositoryIndexes(ctx context.Context, ignoreSignatures bool) (
 	}
 	httpClient := a.client
 	if httpClient == nil {
-		httpClient = &http.Client{}
+		httpClient = retryablehttp.NewClient().StandardClient()
 	}
 	if a.cache != nil {
 		httpClient = a.cache.client(httpClient, true)


### PR DESCRIPTION
Fixes https://github.com/chainguard-dev/go-apk/issues/68