### PR TITLE
Add otel spans

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,9 +17,14 @@ require (
 require (
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-logr/logr v1.2.4 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	go.opentelemetry.io/otel v1.16.0 // indirect
+	go.opentelemetry.io/otel/metric v1.16.0 // indirect
+	go.opentelemetry.io/otel/trace v1.16.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,11 @@ github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
+github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
+github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
@@ -28,6 +33,12 @@ gitlab.alpinelinux.org/alpine/go v0.7.0 h1:N1uWANXNTdu9soAl1eXSs2SQ+gNV4dE0zfJzN
 gitlab.alpinelinux.org/alpine/go v0.7.0/go.mod h1:maZIvJ1++n6Tc3VI+Ta2Sys2OjEmuoXhd92aRzeIjZI=
 go.lsp.dev/uri v0.3.0 h1:KcZJmh6nFIBeJzTugn5JTU6OOyG0lDOo3R9KwTxTYbo=
 go.lsp.dev/uri v0.3.0/go.mod h1:P5sbO1IQR+qySTWOCnhnK7phBx+W3zbLqSMDJNTw88I=
+go.opentelemetry.io/otel v1.16.0 h1:Z7GVAX/UkAXPKsy94IU+i6thsQS4nb7LviLpnaNeW8s=
+go.opentelemetry.io/otel v1.16.0/go.mod h1:vl0h9NUa1D5s1nv3A5vZOYWn8av4K8Ml6JDeHrT/bx4=
+go.opentelemetry.io/otel/metric v1.16.0 h1:RbrpwVG1Hfv85LgnZ7+txXioPDoh6EdbZHo26Q3hqOo=
+go.opentelemetry.io/otel/metric v1.16.0/go.mod h1:QE47cpOmkwipPiefDwo2wDzwJrlfxxNYodqc4xnGCo4=
+go.opentelemetry.io/otel/trace v1.16.0 h1:8JRpaObFoW0pxuVPapkgH8UhHQj+bJW8jJsCZEu5MQs=
+go.opentelemetry.io/otel/trace v1.16.0/go.mod h1:Yt9vYq1SdNz3xdjZZK7wcXv1qv2pwLkqr2QVwea0ef0=
 golang.org/x/build v0.0.0-20220928220451-9294235e16f5 h1:g6/rDfRDvg9YmyUh+Gh15jXoboibZhuv+MiKh8uR8dU=
 golang.org/x/build v0.0.0-20220928220451-9294235e16f5/go.mod h1:09OhLJI8jZv4jqec7zqh+ZlRZKsSZgDyM5MV3pjurk4=
 golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=

--- a/pkg/apk/expandapk.go
+++ b/pkg/apk/expandapk.go
@@ -9,12 +9,15 @@ package apk
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"go.opentelemetry.io/otel"
 )
 
 // The length of a gzip header
@@ -196,7 +199,10 @@ func (r *expandApkReader) EnableFastRead() {
 //
 // Returns an APKExpanded struct containing references to the file. You *must* call APKExpanded.Close()
 // when finished to clean up the various files.
-func ExpandApk(source io.Reader) (*APKExpanded, error) {
+func ExpandApk(ctx context.Context, source io.Reader) (*APKExpanded, error) {
+	ctx, span := otel.Tracer("go-apk").Start(ctx, "ExpandApk")
+	defer span.End()
+
 	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return nil, err

--- a/pkg/apk/index.go
+++ b/pkg/apk/index.go
@@ -33,6 +33,7 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 	"gitlab.alpinelinux.org/alpine/go/repository"
 	"go.lsp.dev/uri"
+	"go.opentelemetry.io/otel"
 )
 
 var signatureFileRegex = regexp.MustCompile(`^\.SIGN\.RSA\.(.*\.rsa\.pub)$`)
@@ -47,6 +48,9 @@ func IndexURL(repo, arch string) string {
 // The key-value pairs in the map for `keys` are the name of the key and the contents of the key.
 // The name is just indicative. If it finds a match, it will use it. Else, it will try all keys.
 func GetRepositoryIndexes(ctx context.Context, repos []string, keys map[string][]byte, arch string, options ...IndexOption) (indexes []NamedIndex, err error) { //nolint:gocyclo
+	ctx, span := otel.Tracer("go-apk").Start(ctx, "GetRepositoryIndexes")
+	defer span.End()
+
 	opts := &indexOpts{}
 	for _, opt := range options {
 		opt(opts)

--- a/pkg/apk/install_test.go
+++ b/pkg/apk/install_test.go
@@ -18,6 +18,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"fmt"
 	"io"
 	"io/fs"
@@ -56,7 +57,7 @@ func TestInstallAPKFiles(t *testing.T) {
 		}
 
 		r := testCreateTGZForPackage(entries)
-		headers, err := apk.installAPKFiles(r, "", "")
+		headers, err := apk.installAPKFiles(context.Background(), r, "", "")
 		require.NoError(t, err)
 
 		require.Equal(t, len(headers), len(entries))
@@ -113,7 +114,7 @@ func TestInstallAPKFiles(t *testing.T) {
 		}
 
 		r := testCreateTGZForPackage(entries)
-		headers, err := apk.installAPKFiles(r, "", "")
+		headers, err := apk.installAPKFiles(context.Background(), r, "", "")
 		require.NoError(t, err)
 
 		require.Equal(t, len(headers), len(entries))
@@ -163,7 +164,7 @@ func TestInstallAPKFiles(t *testing.T) {
 			}
 
 			r := testCreateTGZForPackage(entries)
-			headers, err := apk.installAPKFiles(r, pkg.Origin, "")
+			headers, err := apk.installAPKFiles(context.Background(), r, pkg.Origin, "")
 			require.NoError(t, err)
 			err = apk.addInstalledPackage(pkg, headers)
 			require.NoError(t, err)
@@ -177,7 +178,7 @@ func TestInstallAPKFiles(t *testing.T) {
 			}
 
 			r = testCreateTGZForPackage(entries)
-			_, err = apk.installAPKFiles(r, "second", "")
+			_, err = apk.installAPKFiles(context.Background(), r, "second", "")
 			require.Error(t, err, "some double-write error")
 
 			actual, err = src.ReadFile(overwriteFilename)
@@ -200,7 +201,7 @@ func TestInstallAPKFiles(t *testing.T) {
 			}
 
 			r := testCreateTGZForPackage(entries)
-			headers, err := apk.installAPKFiles(r, pkg.Origin, "")
+			headers, err := apk.installAPKFiles(context.Background(), r, pkg.Origin, "")
 			require.NoError(t, err)
 			err = apk.addInstalledPackage(pkg, headers)
 			require.NoError(t, err)
@@ -214,7 +215,7 @@ func TestInstallAPKFiles(t *testing.T) {
 			}
 
 			r = testCreateTGZForPackage(entries)
-			_, err = apk.installAPKFiles(r, "second", "first")
+			_, err = apk.installAPKFiles(context.Background(), r, "second", "first")
 			require.NoError(t, err)
 
 			actual, err = src.ReadFile(overwriteFilename)
@@ -236,7 +237,7 @@ func TestInstallAPKFiles(t *testing.T) {
 			pkg := &repository.Package{Name: "first", Origin: "first"}
 
 			r := testCreateTGZForPackage(entries)
-			headers, err := apk.installAPKFiles(r, pkg.Origin, "")
+			headers, err := apk.installAPKFiles(context.Background(), r, pkg.Origin, "")
 			require.NoError(t, err)
 			err = apk.addInstalledPackage(pkg, headers)
 			require.NoError(t, err)
@@ -250,7 +251,7 @@ func TestInstallAPKFiles(t *testing.T) {
 			}
 
 			r = testCreateTGZForPackage(entries)
-			_, err = apk.installAPKFiles(r, pkg.Origin, "")
+			_, err = apk.installAPKFiles(context.Background(), r, pkg.Origin, "")
 			require.NoError(t, err)
 
 			actual, err = src.ReadFile(overwriteFilename)
@@ -272,7 +273,7 @@ func TestInstallAPKFiles(t *testing.T) {
 			}
 
 			r := testCreateTGZForPackage(entries)
-			headers, err := apk.installAPKFiles(r, pkg.Origin, "")
+			headers, err := apk.installAPKFiles(context.Background(), r, pkg.Origin, "")
 			require.NoError(t, err)
 			err = apk.addInstalledPackage(pkg, headers)
 			require.NoError(t, err)
@@ -286,7 +287,7 @@ func TestInstallAPKFiles(t *testing.T) {
 			}
 
 			r = testCreateTGZForPackage(entries)
-			_, err = apk.installAPKFiles(r, "second", "")
+			_, err = apk.installAPKFiles(context.Background(), r, "second", "")
 			require.NoError(t, err)
 
 			actual, err = src.ReadFile(overwriteFilename)

--- a/pkg/apk/repo_test.go
+++ b/pkg/apk/repo_test.go
@@ -347,8 +347,8 @@ func TestGetPackagesWithDependences(t *testing.T) {
 		// - find all of the dependencies of all of the packages
 		// - eliminate duplicates
 		// - reverse the order, so that it is in order of installation
-		resolver := NewPkgResolver(testNamedRepositoryFromIndexes(index))
-		pkgs, _, err := resolver.GetPackagesWithDependencies(names)
+		resolver := NewPkgResolver(context.Background(), testNamedRepositoryFromIndexes(index))
+		pkgs, _, err := resolver.GetPackagesWithDependencies(context.Background(), names)
 		require.NoErrorf(t, err, "unable to get packages")
 		var actual = make([]string, 0, len(pkgs))
 		for _, pkg := range pkgs {
@@ -364,12 +364,12 @@ func TestGetPackagesWithDependences(t *testing.T) {
 		// we use abc9 -> package5 rather than package9 -> package5, because world sorts alphabetically,
 		// and we want to ensure that, even though abc9 is processed first, package5 override still works.
 		_, index := testGetPackagesAndIndex()
-		resolver := NewPkgResolver(testNamedRepositoryFromIndexes(index))
+		resolver := NewPkgResolver(context.Background(), testNamedRepositoryFromIndexes(index))
 		t.Run("same name no lock", func(t *testing.T) {
 			name, version := "package5", "2.0.0" //nolint:goconst // no, we do not want to make it a constant
 			names := []string{name, "abc9"}
 			sort.Strings(names)
-			pkgs, _, err := resolver.GetPackagesWithDependencies(names)
+			pkgs, _, err := resolver.GetPackagesWithDependencies(context.Background(), names)
 			require.NoErrorf(t, err, "unable to get packages")
 			require.Len(t, pkgs, 2)
 			for _, pkg := range pkgs {
@@ -383,7 +383,7 @@ func TestGetPackagesWithDependences(t *testing.T) {
 			name, version := "package5", "1.5.1"
 			names := []string{fmt.Sprintf("%s=%s", name, version), "abc9"}
 			sort.Strings(names)
-			pkgs, _, err := resolver.GetPackagesWithDependencies(names)
+			pkgs, _, err := resolver.GetPackagesWithDependencies(context.Background(), names)
 			require.NoErrorf(t, err, "unable to get packages")
 			require.Len(t, pkgs, 2)
 			for _, pkg := range pkgs {
@@ -397,7 +397,7 @@ func TestGetPackagesWithDependences(t *testing.T) {
 			providesName, version := "package5-special", "1.2.0"
 			names := []string{providesName, "abc9"}
 			sort.Strings(names)
-			pkgs, _, err := resolver.GetPackagesWithDependencies(names)
+			pkgs, _, err := resolver.GetPackagesWithDependencies(context.Background(), names)
 			require.NoErrorf(t, err, "unable to get packages")
 			require.Len(t, pkgs, 2)
 			for _, pkg := range pkgs {
@@ -415,7 +415,7 @@ func TestGetPackageDependencies(t *testing.T) {
 		expected := []string{"dep4", "dep5", "dep1", "dep6", "foo", "libq", "dep3", "busybox", "dep2"}
 		_, index := testGetPackagesAndIndex()
 
-		resolver := NewPkgResolver(testNamedRepositoryFromIndexes(index))
+		resolver := NewPkgResolver(context.Background(), testNamedRepositoryFromIndexes(index))
 		_, pkgs, _, err := resolver.GetPackageWithDependencies("package1", nil)
 		require.NoErrorf(t, err, "unable to get dependencies")
 
@@ -430,7 +430,7 @@ func TestGetPackageDependencies(t *testing.T) {
 		expected := []string{"dep8"}
 		_, index := testGetPackagesAndIndex()
 
-		resolver := NewPkgResolver(testNamedRepositoryFromIndexes(index))
+		resolver := NewPkgResolver(context.Background(), testNamedRepositoryFromIndexes(index))
 		_, pkgs, _, err := resolver.GetPackageWithDependencies("package3", nil)
 		require.NoErrorf(t, err, "unable to get dependencies")
 
@@ -443,7 +443,7 @@ func TestGetPackageDependencies(t *testing.T) {
 	t.Run("self-fulfill", func(t *testing.T) {
 		_, index := testGetPackagesAndIndex()
 
-		resolver := NewPkgResolver(testNamedRepositoryFromIndexes(index))
+		resolver := NewPkgResolver(context.Background(), testNamedRepositoryFromIndexes(index))
 		pkg6, err := resolver.ResolvePackage("package6")
 		require.NoErrorf(t, err, "unable to resolve package6")
 		require.GreaterOrEqual(t, len(pkg6), 1, "package6 should have at least one match")
@@ -470,7 +470,7 @@ func TestGetPackageDependencies(t *testing.T) {
 	})
 	t.Run("existing dependency", func(t *testing.T) {
 		origPkgs, index := testGetPackagesAndIndex()
-		resolver := NewPkgResolver(testNamedRepositoryFromIndexes(index))
+		resolver := NewPkgResolver(context.Background(), testNamedRepositoryFromIndexes(index))
 
 		// start with regular resolution, just to compare
 		expectedName := "package5"
@@ -504,7 +504,7 @@ func TestResolvePackage(t *testing.T) {
 		// getPackageDependencies does not get the same dependencies twice.
 		_, index := testGetPackagesAndIndex()
 
-		resolver := NewPkgResolver(testNamedRepositoryFromIndexes(index))
+		resolver := NewPkgResolver(context.Background(), testNamedRepositoryFromIndexes(index))
 		pkgs, err := resolver.ResolvePackage("package12")
 		require.Error(t, err)
 		require.Len(t, pkgs, 0)
@@ -513,7 +513,7 @@ func TestResolvePackage(t *testing.T) {
 		// getPackageDependencies does not get the same dependencies twice.
 		_, index := testGetPackagesAndIndex()
 
-		resolver := NewPkgResolver(testNamedRepositoryFromIndexes(index))
+		resolver := NewPkgResolver(context.Background(), testNamedRepositoryFromIndexes(index))
 		pkgs, err := resolver.ResolvePackage("package5")
 		require.NoError(t, err)
 		require.Len(t, pkgs, 5)
@@ -522,7 +522,7 @@ func TestResolvePackage(t *testing.T) {
 		// getPackageDependencies does not get the same dependencies twice.
 		_, index := testGetPackagesAndIndex()
 
-		resolver := NewPkgResolver(testNamedRepositoryFromIndexes(index))
+		resolver := NewPkgResolver(context.Background(), testNamedRepositoryFromIndexes(index))
 		version := "1.0.0"
 		pkgs, err := resolver.ResolvePackage("package5=" + version)
 		require.NoError(t, err)
@@ -539,7 +539,7 @@ func TestResolvePackage(t *testing.T) {
 		// getPackageDependencies does not get the same dependencies twice.
 		_, index := testGetPackagesAndIndex()
 
-		resolver := NewPkgResolver(testNamedRepositoryFromIndexes(index))
+		resolver := NewPkgResolver(context.Background(), testNamedRepositoryFromIndexes(index))
 		pkgs, err := resolver.ResolvePackage("package5>1.0.0")
 		require.NoError(t, err)
 		require.Len(t, pkgs, 4)
@@ -550,7 +550,7 @@ func TestResolvePackage(t *testing.T) {
 		// getPackageDependencies does not get the same dependencies twice.
 		_, index := testGetPackagesAndIndex()
 
-		resolver := NewPkgResolver(testNamedRepositoryFromIndexes(index))
+		resolver := NewPkgResolver(context.Background(), testNamedRepositoryFromIndexes(index))
 		pkgs, err := resolver.ResolvePackage("package7")
 		require.NoError(t, err)
 		require.Len(t, pkgs, 2)
@@ -572,7 +572,7 @@ func TestVersionHierarchy(t *testing.T) {
 			{Name: "multi-versioner", Version: "2.0.6-r0"},
 		},
 	})
-	resolver := NewPkgResolver(testNamedRepositoryFromIndexes([]*repository.RepositoryWithIndex{index}))
+	resolver := NewPkgResolver(context.Background(), testNamedRepositoryFromIndexes([]*repository.RepositoryWithIndex{index}))
 	pkgWithVersions, ok := resolver.nameMap["multi-versioner"]
 	require.True(t, ok, "found multi-versioner in nameMap")
 	for i, pkg := range pkgWithVersions {

--- a/pkg/tarball/write.go
+++ b/pkg/tarball/write.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"syscall"
 
+	"go.opentelemetry.io/otel"
 	gzip "golang.org/x/build/pargzip"
 	"golang.org/x/sys/unix"
 
@@ -278,6 +279,9 @@ func (c *Context) WriteArchive(dst io.Writer, src fs.FS) error {
 // To override permissions, set the OverridePerms when creating the Context.
 // If you need to get multiple filesystems, merge them prior to calling WriteArchive.
 func (c *Context) WriteTargz(ctx context.Context, dst io.Writer, src fs.FS) error {
+	ctx, span := otel.Tracer("go-apk").Start(ctx, "WriteTargz")
+	defer span.End()
+
 	gzw := gzip.NewWriter(dst)
 	defer gzw.Close()
 
@@ -288,6 +292,9 @@ func (c *Context) WriteTargz(ctx context.Context, dst io.Writer, src fs.FS) erro
 // To override permissions, set the OverridePerms when creating the Context.
 // If you need to get multiple filesystems, merge them prior to calling WriteArchive.
 func (c *Context) WriteTar(ctx context.Context, dst io.Writer, src fs.FS) error {
+	ctx, span := otel.Tracer("go-apk").Start(ctx, "WriteTar")
+	defer span.End()
+
 	tw := tar.NewWriter(dst)
 	if !c.SkipClose {
 		defer tw.Close()


### PR DESCRIPTION
This will allow us to visualize where our latency is coming from. I've plumbed contexts around where necessary.

The coverage isn't perfect, and we'll probably want to instrument outgoing HTTP requests with traces as well, but this is a good start for things we know are slow.