### PR TITLE
Memoize version parsing, filtering, and sorting

### DIFF
--- a/pkg/apk/repo_test.go
+++ b/pkg/apk/repo_test.go
@@ -656,7 +656,8 @@ func TestSortPackages(t *testing.T) {
 				existing[pkg.pkg.Name] = repository.NewRepositoryPackage(pkg.pkg, &repository.RepositoryWithIndex{Repository: &repository.Repository{Uri: pkg.repo}})
 			}
 			namedPkgs := testNamedPackageFromPackages(pkgs)
-			sortPackages(namedPkgs, pkg, "", existing, "")
+			pr := NewPkgResolver(context.Background(), []NamedIndex{})
+			pr.sortPackages(namedPkgs, pkg, "", existing, "")
 			for i, pkg := range namedPkgs {
 				require.Equal(t, int(pkg.InstalledSize), i, "position matches")
 			}

--- a/pkg/apk/version_test.go
+++ b/pkg/apk/version_test.go
@@ -15,6 +15,7 @@
 package apk
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -886,13 +887,14 @@ func TestResolveVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			found := filterPackages(pkgs, withVersion(tt.version, tt.compare), withPreferPin(tt.pin), withInstalledPackage(tt.installed))
+			pr := NewPkgResolver(context.Background(), []NamedIndex{})
+			found := pr.filterPackages(pkgs, withVersion(tt.version, tt.compare), withPreferPin(tt.pin), withInstalledPackage(tt.installed))
 			// add the existing in, if any
 			existing := make(map[string]*repository.RepositoryPackage)
 			if tt.installed != nil {
 				existing[tt.installed.Name] = tt.installed
 			}
-			sortPackages(found, nil, "", existing, tt.pin)
+			pr.sortPackages(found, nil, "", existing, tt.pin)
 			if tt.want == "" {
 				require.Nil(t, found, "version resolver should not find a package")
 			} else {
@@ -925,11 +927,11 @@ func TestResolverPackageNameVersionPin(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			name, version, dep, pin := resolvePackageNameVersionPin(tt.input)
-			require.Equal(t, tt.name, name)
-			require.Equal(t, tt.version, version)
-			require.Equal(t, tt.dep, dep)
-			require.Equal(t, tt.pin, pin)
+			stuff := resolvePackageNameVersionPin(tt.input)
+			require.Equal(t, tt.name, stuff.name)
+			require.Equal(t, tt.version, stuff.version)
+			require.Equal(t, tt.dep, stuff.dep)
+			require.Equal(t, tt.pin, stuff.pin)
 		})
 	}
 }


### PR DESCRIPTION
We were spending a good chunk of CPU time inside regular expressions for parseVersion. This change is kinda janky, but it memoizes the results of various regular expressions so we don't pay for it multiple times.

This can be a lot better, but it's an easy win for now.