### PR TITLE
feat: support HTTP basic auth in repo and key url's

### DIFF
--- a/pkg/apk/implementation.go
+++ b/pkg/apk/implementation.go
@@ -328,7 +328,7 @@ func (a *APK) loadSystemKeyring(locations ...string) ([]string, error) {
 }
 
 // Installs the specified keys into the APK keyring inside the build context.
-func (a *APK) InitKeyring(ctx context.Context, keyFiles, extraKeyFiles []string) (err error) {
+func (a *APK) InitKeyring(ctx context.Context, keyFiles, extraKeyFiles []string) error {
 	a.logger.Infof("initializing apk keyring")
 
 	ctx, span := otel.Tracer("go-apk").Start(ctx, "InitKeyring")

--- a/pkg/apk/implementation.go
+++ b/pkg/apk/implementation.go
@@ -152,7 +152,7 @@ func (a *APK) SetClient(client *http.Client) {
 
 // ListInitFiles list the files that are installed during the InitDB phase.
 func (a *APK) ListInitFiles() []tar.Header {
-	var headers = make([]tar.Header, 0, 20)
+	headers := make([]tar.Header, 0, 20)
 
 	// additionalFiles are files we need but can only be resolved in the context of
 	// this func, e.g. we need the architecture
@@ -350,18 +350,19 @@ func (a *APK) InitKeyring(ctx context.Context, keyFiles, extraKeyFiles []string)
 		eg.Go(func() error {
 			a.logger.Debugf("installing key %v", element)
 
-			// Normalize the element as a URI, so that local paths
-			// are translated into file:// URLs, allowing them to be parsed
-			// into a url.URL{}.
-			var asURI uri.URI
+			var asURL *url.URL
 			if strings.HasPrefix(element, "https://") {
-				asURI, _ = uri.Parse(element)
+				asURL, err = url.Parse(element)
+				if err != nil {
+					return fmt.Errorf("failed to parse key as URI: %w", err)
+				}
 			} else {
-				asURI = uri.New(element)
-			}
-			asURL, err := url.Parse(string(asURI))
-			if err != nil {
-				return fmt.Errorf("failed to parse key as URI: %w", err)
+				// Attempt to parse non-https elements into URI's so they are translated into
+				// file:// URLs allowing them to parse into a url.URL{}
+				asURL, err = url.Parse(string(uri.New(element)))
+				if err != nil {
+					return fmt.Errorf("failed to parse key as URI: %w", err)
+				}
 			}
 
 			var data []byte
@@ -380,6 +381,13 @@ func (a *APK) InitKeyring(ctx context.Context, keyFiles, extraKeyFiles []string)
 				if err != nil {
 					return err
 				}
+				// if the URL contains HTTP Basic Auth credentials, add them to the request
+				if asURL.User != nil {
+					user := asURL.User.Username()
+					pass, _ := asURL.User.Password()
+					req.SetBasicAuth(user, pass)
+				}
+
 				resp, err := client.Do(req)
 				if err != nil {
 					return fmt.Errorf("failed to fetch apk key: %w", err)
@@ -387,7 +395,7 @@ func (a *APK) InitKeyring(ctx context.Context, keyFiles, extraKeyFiles []string)
 				defer resp.Body.Close()
 
 				if resp.StatusCode < 200 || resp.StatusCode > 299 {
-					return errors.New("failed to fetch apk key: http response indicated error")
+					return fmt.Errorf("failed to fetch apk key: http response indicated error code: %d", resp.StatusCode)
 				}
 
 				data, err = io.ReadAll(resp.Body)
@@ -642,7 +650,7 @@ func (a *APK) cachePackage(ctx context.Context, pkg *repository.RepositoryPackag
 		return nil, err
 	}
 
-	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 		return nil, fmt.Errorf("unable to create cache directory %q: %w", cacheDir, err)
 	}
 

--- a/pkg/apk/implementation.go
+++ b/pkg/apk/implementation.go
@@ -351,18 +351,16 @@ func (a *APK) InitKeyring(ctx context.Context, keyFiles, extraKeyFiles []string)
 			a.logger.Debugf("installing key %v", element)
 
 			var asURL *url.URL
+			var err error
 			if strings.HasPrefix(element, "https://") {
 				asURL, err = url.Parse(element)
-				if err != nil {
-					return fmt.Errorf("failed to parse key as URI: %w", err)
-				}
 			} else {
 				// Attempt to parse non-https elements into URI's so they are translated into
 				// file:// URLs allowing them to parse into a url.URL{}
 				asURL, err = url.Parse(string(uri.New(element)))
-				if err != nil {
-					return fmt.Errorf("failed to parse key as URI: %w", err)
-				}
+			}
+			if err != nil {
+				return fmt.Errorf("failed to parse key as URI: %w", err)
 			}
 
 			var data []byte

--- a/pkg/apk/implementation_test.go
+++ b/pkg/apk/implementation_test.go
@@ -190,6 +190,15 @@ func TestInitKeyring(t *testing.T) {
 		"http://sldkjflskdjflklksdlksdlkjslk.net",
 	}
 	require.Error(t, a.InitKeyring(context.Background(), keyfiles, nil))
+
+	// add a remote key with HTTP Basic Auth
+	keyfiles = []string{
+		"https://user:pass@alpinelinux.org/keys/alpine-devel%40lists.alpinelinux.org-4a6a0840.rsa.pub",
+	}
+	a.SetClient(&http.Client{
+		Transport: &testLocalTransport{root: testPrimaryPkgDir, basenameOnly: true, requireBasicAuth: true},
+	})
+	require.NoError(t, a.InitKeyring(context.Background(), keyfiles, nil))
 }
 
 func TestLoadSystemKeyring(t *testing.T) {
@@ -279,7 +288,7 @@ func TestFetchPackage(t *testing.T) {
 		pkg      = repository.NewRepositoryPackage(&testPkg, repoWithIndex)
 		ctx      = context.Background()
 	)
-	var prepLayout = func(t *testing.T, cache string) *APK {
+	prepLayout := func(t *testing.T, cache string) *APK {
 		src := apkfs.NewMemFS()
 		err := src.MkdirAll("lib/apk/db", 0o755)
 		require.NoError(t, err, "unable to mkdir /lib/apk/db")

--- a/pkg/apk/index.go
+++ b/pkg/apk/index.go
@@ -80,16 +80,20 @@ func GetRepositoryIndexes(ctx context.Context, repos []string, keys map[string][
 		// into a url.URL{}.
 		var (
 			b     []byte
-			asURI uri.URI
+			asURL *url.URL
 		)
 		if strings.HasPrefix(u, "https://") {
-			asURI, _ = uri.Parse(u)
+			asURL, err = url.Parse(u)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse repo as URI: %w", err)
+			}
 		} else {
-			asURI = uri.New(u)
-		}
-		asURL, err := url.Parse(string(asURI))
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse repo as URI: %w", err)
+			// Attempt to parse non-https repos into URI's so they are translated into
+			// file:// URLs allowing them to parse into a url.URL{}
+			asURL, err = url.Parse(string(uri.New(u)))
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse repo as URI: %w", err)
+			}
 		}
 
 		switch asURL.Scheme {
@@ -109,6 +113,12 @@ func GetRepositoryIndexes(ctx context.Context, repos []string, keys map[string][
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, asURL.String(), nil)
 			if err != nil {
 				return nil, err
+			}
+			// if the repo URL contains HTTP Basic Auth credentials, add them to the request
+			if asURL.User != nil {
+				user := asURL.User.Username()
+				pass, _ := asURL.User.Password()
+				req.SetBasicAuth(user, pass)
 			}
 			res, err := client.Do(req)
 			if err != nil {

--- a/pkg/apk/index.go
+++ b/pkg/apk/index.go
@@ -84,16 +84,13 @@ func GetRepositoryIndexes(ctx context.Context, repos []string, keys map[string][
 		)
 		if strings.HasPrefix(u, "https://") {
 			asURL, err = url.Parse(u)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse repo as URI: %w", err)
-			}
 		} else {
-			// Attempt to parse non-https repos into URI's so they are translated into
+			// Attempt to parse non-https elements into URI's so they are translated into
 			// file:// URLs allowing them to parse into a url.URL{}
 			asURL, err = url.Parse(string(uri.New(u)))
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse repo as URI: %w", err)
-			}
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse repo as URI: %w", err)
 		}
 
 		switch asURL.Scheme {


### PR DESCRIPTION
The standard alpine `apk` util supports HTTP Basic Auth, and this allows go-apk and tools such as `apko` to support it as well.

Implements https://github.com/chainguard-dev/apko/issues/794

I've successfully tested this using the example `apko.yaml` listed in https://github.com/chainguard-dev/apko/issues/794 with a private HTTPS repo.

There are two key changes that made this work:

1. When repo or key URLs are parsed they are first run thru `uri.Parse()` then passed into `url.Parse()` to generate a usable `url.URL{}`. This is done to ensure local paths were rewritten as `file://` for compatibility with `url.Parse()`. However this removes the http basic auth info from the URL. Instead, we directly parse https:// URLs with `url.Parse()` and run all other url types thru `uri.Parse()` before `url.Parse()`
2.  When generating a new `http.Request`, check for `url.User != nil` and add auth info to the request by calling `SetBasicAuth()`.