### PR TITLE
Create temp files inside cacheDir

### DIFF
--- a/pkg/apk/expandapk.go
+++ b/pkg/apk/expandapk.go
@@ -238,11 +238,11 @@ func (r *expandApkReader) EnableFastRead() {
 //
 // Returns an APKExpanded struct containing references to the file. You *must* call APKExpanded.Close()
 // when finished to clean up the various files.
-func ExpandApk(ctx context.Context, source io.Reader) (*APKExpanded, error) {
+func ExpandApk(ctx context.Context, source io.Reader, cacheDir string) (*APKExpanded, error) {
 	ctx, span := otel.Tracer("go-apk").Start(ctx, "ExpandApk")
 	defer span.End()
 
-	dir, err := os.MkdirTemp("", "")
+	dir, err := os.MkdirTemp(cacheDir, "expand-apk")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apk/implementation_test.go
+++ b/pkg/apk/implementation_test.go
@@ -345,7 +345,7 @@ func TestFetchPackage(t *testing.T) {
 		_, err = os.Stat(cacheApkDir)
 		require.NoError(t, err, "apk file not found in cache")
 		// check that the contents are the same
-		exp, err := a.cachedPackage(ctx, pkg)
+		exp, err := a.cachedPackage(ctx, pkg, cacheApkDir)
 		if err != nil {
 			t.Logf("did not find cachedPackage(%q) in %s: %v", pkg.Name, cacheApkDir, err)
 			files, err := os.ReadDir(cacheApkDir)


### PR DESCRIPTION
This ensures the destination in the cacheDir is on the same device as the temporary file so that we can Rename them.