### PR TITLE
Add a retrying Range transport

### DIFF
--- a/pkg/apk/implementation.go
+++ b/pkg/apk/implementation.go
@@ -843,7 +843,10 @@ func (a *APK) fetchPackage(ctx context.Context, pkg *repository.RepositoryPackag
 		if err != nil {
 			return nil, err
 		}
-		res, err := client.Do(req)
+
+		// This will return a body that retries requests using Range requests if Read() hits an error.
+		rrt := newRangeRetryTransport(ctx, client)
+		res, err := rrt.RoundTrip(req)
 		if err != nil {
 			return nil, fmt.Errorf("unable to get package apk at %s: %w", u, err)
 		}

--- a/pkg/apk/transport.go
+++ b/pkg/apk/transport.go
@@ -1,0 +1,142 @@
+// Copyright 2023 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apk
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+type rangeRetryTransport struct {
+	client *http.Client
+	ctx    context.Context
+}
+
+func newRangeRetryTransport(ctx context.Context, client *http.Client) *rangeRetryTransport {
+	return &rangeRetryTransport{
+		client: client,
+		ctx:    ctx,
+	}
+}
+
+func (t *rangeRetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	r := rangeRetryReader{
+		client: t.client,
+		ctx:    t.ctx,
+		req:    req,
+	}
+
+	return r.reset(nil)
+}
+
+type rangeRetryReader struct {
+	client *http.Client
+	ctx    context.Context
+
+	req *http.Request
+
+	body io.ReadCloser
+
+	progress int64
+	total    int64
+}
+
+func (r *rangeRetryReader) reset(oerr error) (*http.Response, error) {
+	if r.body != nil {
+		// Intentionally ignoring this because we no longer care about the previous body.
+		_ = r.body.Close()
+	}
+
+	req := r.req.WithContext(r.ctx)
+
+	rangeHeader := fmt.Sprintf("bytes=%d-", r.progress)
+	if r.progress != 0 {
+		req.Header.Set("Range", rangeHeader)
+	}
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return resp, errors.Join(oerr, err)
+	}
+
+	if resp.Body == nil || resp.Body == http.NoBody {
+		return resp, nil
+	}
+
+	if r.total == 0 {
+		r.total = resp.ContentLength
+	}
+
+	if resp.StatusCode == http.StatusOK {
+		// If the upstream doesn't support Range requests for some reason and only returns 200,
+		// we need to discard anything we've already Read().
+		if r.progress != 0 {
+			if _, err := io.CopyN(io.Discard, resp.Body, r.progress); err != nil {
+				return resp, err
+			}
+		}
+	} else if resp.StatusCode != http.StatusPartialContent {
+		return resp, fmt.Errorf("retrying %w: %s %s (Range: %s): unexpected status code: %d", oerr, req.Method, req.URL.String(), rangeHeader, resp.StatusCode)
+	}
+
+	r.body = resp.Body
+	resp.Body = r
+
+	return resp, nil
+}
+
+func (r *rangeRetryReader) Read(p []byte) (n int, err error) {
+	defer func() {
+		r.progress += int64(n)
+	}()
+
+	// If Read() fails, we will reset() 2x.
+	for _, retry := range []bool{true, true, false} {
+		n, err = r.body.Read(p)
+		if err == nil {
+			break
+		}
+
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		if !retry {
+			break
+		}
+
+		// Send a Range request in an attempt to save this io.Reader.
+		resp, rerr := r.reset(err)
+		if rerr != nil {
+			if resp != nil && resp.Body != nil {
+				resp.Body.Close()
+			}
+			return n, errors.Join(rerr, err)
+		}
+	}
+
+	return n, err
+}
+
+func (r *rangeRetryReader) Close() error {
+	if r.body == nil {
+		return nil
+	}
+
+	return r.body.Close()
+}

--- a/pkg/apk/transport_test.go
+++ b/pkg/apk/transport_test.go
@@ -1,0 +1,199 @@
+// Copyright 2023 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apk
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+	"testing/iotest"
+)
+
+type testReader struct {
+	readers []io.Reader
+	count   int
+}
+
+func (r *testReader) Read(p []byte) (int, error) {
+	if r.count == len(r.readers) {
+		return 0, io.EOF
+	}
+
+	n, err := r.readers[r.count].Read(p)
+	if err != nil {
+		r.count++
+	}
+
+	return n, err
+}
+
+func (r *testReader) Close() error {
+	return nil
+}
+
+type testTransport struct {
+	rc     io.ReadCloser
+	resps  []*http.Response
+	ranges []int
+	count  int
+}
+
+func (t *testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.count == len(t.resps) {
+		return nil, fmt.Errorf("this shouldn't happen")
+	}
+
+	want := ""
+	if r := t.ranges[t.count]; r != 0 {
+		want = fmt.Sprintf("bytes=%d-", t.ranges[t.count])
+	}
+	if got := req.Header.Get("Range"); want != got {
+		return nil, fmt.Errorf("wrong range, want %q, got %q", want, got)
+	}
+	resp := t.resps[t.count]
+	if resp != nil {
+		resp.Body = t.rc
+	}
+	t.count++
+	return resp, nil
+}
+
+func cb() []byte {
+	return bytes.Repeat([]byte("chainguard"), 1000)
+}
+
+func cr() io.Reader {
+	return bytes.NewReader(cb())
+}
+
+func er() io.Reader {
+	return iotest.ErrReader(fmt.Errorf("this is an error"))
+}
+
+func mr(rs ...io.Reader) io.Reader {
+	return io.MultiReader(rs...)
+}
+
+func part() *http.Response {
+	r := ok(1)
+	r.StatusCode = http.StatusPartialContent
+
+	return r
+}
+
+func ok(n int) *http.Response {
+	return &http.Response{
+		StatusCode:    http.StatusOK,
+		ContentLength: int64(len(cb()) * n),
+	}
+}
+
+func TestTransport(t *testing.T) {
+	size := len(cb())
+
+	fail := &http.Response{
+		StatusCode: http.StatusInternalServerError,
+	}
+
+	for i, tc := range []struct {
+		name    string
+		readers []io.Reader
+		resps   []*http.Response
+		ranges  []int
+		want    io.Reader
+		wantErr bool
+	}{{
+		name:    "normal success",
+		readers: []io.Reader{mr(cr(), cr())},
+		resps:   []*http.Response{ok(2)}, //nolint:bodyclose
+		ranges:  []int{0, size},
+		want:    mr(cr(), cr()),
+	}, {
+		name:    "retry error once",
+		readers: []io.Reader{mr(cr(), er()), cr()},
+		resps:   []*http.Response{ok(2), part()}, //nolint:bodyclose
+		ranges:  []int{0, size},
+		want:    mr(cr(), cr()),
+	}, {
+		name:    "retry error twice",
+		readers: []io.Reader{mr(cr(), cr(), er()), er(), cr()},
+		resps:   []*http.Response{ok(3), part(), part()}, //nolint:bodyclose
+		ranges:  []int{0, size * 2, size * 2},
+		want:    mr(cr(), cr(), cr()),
+	}, {
+		name:    "retry error thrice",
+		readers: []io.Reader{mr(cr(), cr(), er()), er(), er(), cr()},
+		resps:   []*http.Response{ok(3), part(), part(), part()}, //nolint:bodyclose
+		ranges:  []int{0, size * 2, size * 2, size * 2},
+		want:    mr(cr(), cr()),
+		wantErr: true,
+	}, {
+		name:    "retry hits 500",
+		readers: []io.Reader{mr(cr(), cr(), er())},
+		resps:   []*http.Response{ok(3), fail}, //nolint:bodyclose
+		ranges:  []int{0, size * 2},
+		want:    mr(cr(), cr()),
+		wantErr: true,
+	}, {
+		name:    "no partial response from server (must discard)",
+		readers: []io.Reader{mr(cr(), er()), mr(cr(), cr())},
+		resps:   []*http.Response{ok(2), ok(2)}, //nolint:bodyclose
+		ranges:  []int{0, size},
+		want:    mr(cr(), cr()),
+	}} {
+		name := fmt.Sprintf("[%d]", i)
+		t.Run(name, func(t *testing.T) {
+			tr := &testReader{tc.readers, 0}
+			tt := &testTransport{
+				rc:     tr,
+				resps:  tc.resps,
+				ranges: tc.ranges,
+			}
+
+			rt := newRangeRetryTransport(context.Background(), &http.Client{Transport: tt})
+
+			req := &http.Request{
+				URL:    &url.URL{},
+				Header: map[string][]string{},
+			}
+
+			resp, err := rt.RoundTrip(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+
+			got, err := io.ReadAll(resp.Body)
+			if err != nil && !tc.wantErr {
+				t.Fatal(err)
+			}
+
+			want, err := io.ReadAll(tc.want)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(got, want) {
+				t.Errorf("not equal!")
+				t.Errorf("got  (%d): %s", len(got), got)
+				t.Errorf("want (%d): %s", len(want), want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This attempts to deal with flaky connections when fetching APKs. Because they're fairly large, we attempt to use Range requests to avoid re-downloading everything.