### PR TITLE
Use io.CopyBuffer when recomputing checksums

### DIFF
--- a/pkg/tarball/write.go
+++ b/pkg/tarball/write.go
@@ -223,7 +223,7 @@ func (c *Context) writeTar(ctx context.Context, tw *tar.Writer, fsys fs.FS, user
 				defer data.Close()
 
 				fileDigest := sha1.New() //nolint:gosec
-				if _, err := io.Copy(fileDigest, data); err != nil {
+				if _, err := io.CopyBuffer(fileDigest, data, buf); err != nil {
 					return err
 				}
 


### PR DESCRIPTION
This should be something we can optimize away entirely, but this makes BuildTarball ~50% faster when building go1.21.