### PR TITLE
Introduce offline mode

### DIFF
--- a/pkg/apk/implementation.go
+++ b/pkg/apk/implementation.go
@@ -373,6 +373,9 @@ func (a *APK) InitKeyring(ctx context.Context, keyFiles, extraKeyFiles []string)
 				if client == nil {
 					client = retryablehttp.NewClient().StandardClient()
 				}
+				if a.cache != nil {
+					client = a.cache.client(client, true)
+				}
 				req, err := http.NewRequestWithContext(ctx, http.MethodGet, asURL.String(), nil)
 				if err != nil {
 					return err

--- a/pkg/apk/implementation_test.go
+++ b/pkg/apk/implementation_test.go
@@ -295,7 +295,7 @@ func TestFetchPackage(t *testing.T) {
 
 		opts := []Option{WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors)}
 		if cache != "" {
-			opts = append(opts, WithCache(cache))
+			opts = append(opts, WithCache(cache, false))
 		}
 		a, err := New(opts...)
 		require.NoError(t, err, "unable to create APK")

--- a/pkg/apk/options.go
+++ b/pkg/apk/options.go
@@ -88,7 +88,10 @@ func WithFS(fs apkfs.FullFS) Option {
 
 // WithCache sets to use a cache directory for downloaded apk files and APKINDEX files.
 // If not provided, will not cache.
-func WithCache(cacheDir string) Option {
+//
+// If offline is true, only read from the cache and do not make any network requests to
+// populate it.
+func WithCache(cacheDir string, offline bool) Option {
 	return func(o *opts) error {
 		var err error
 		if cacheDir == "" {
@@ -98,7 +101,10 @@ func WithCache(cacheDir string) Option {
 			}
 			cacheDir = filepath.Join(cacheDir, "dev.chainguard.go-apk")
 		}
-		o.cache = &cache{dir: cacheDir}
+		o.cache = &cache{
+			dir:     cacheDir,
+			offline: offline,
+		}
 		return nil
 	}
 }

--- a/pkg/apk/repo_test.go
+++ b/pkg/apk/repo_test.go
@@ -95,7 +95,7 @@ func TestGetRepositoryIndexes(t *testing.T) {
 
 		opts := []Option{WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors)}
 		if cache != "" {
-			opts = append(opts, WithCache(cache))
+			opts = append(opts, WithCache(cache, false))
 		}
 		a, err := New(opts...)
 		require.NoError(t, err, "unable to create APK")


### PR DESCRIPTION
For APKINDEX.tar.gz and keys, this will select the most recently cached file and fail if there are no options. In order for that to work, we also had to start caching keys offline.