### PR TITLE
Drop offset from WriteHeader interface

### DIFF
--- a/pkg/apk/implementation.go
+++ b/pkg/apk/implementation.go
@@ -867,7 +867,7 @@ func (a *APK) fetchPackage(ctx context.Context, pkg *repository.RepositoryPackag
 }
 
 type writeHeaderer interface {
-	WriteHeader(hdr tar.Header, tfs fs.FS, offset int64, pkg *repository.Package) error
+	WriteHeader(hdr tar.Header, tfs fs.FS, pkg *repository.Package) error
 }
 
 // installPackage installs a single package and updates installed db.

--- a/pkg/apk/install.go
+++ b/pkg/apk/install.go
@@ -315,7 +315,7 @@ func (a *APK) lazilyInstallAPKFiles(ctx context.Context, wh writeHeaderer, tf *t
 		// whatever it is now, it is in the data section
 		startedDataSection = true
 
-		if err := wh.WriteHeader(header.Header, tf, header.Offset, pkg); err != nil {
+		if err := wh.WriteHeader(header.Header, tf, pkg); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
We don't actually need this because the fs stores it.