### PR TITLE
Make two methods public.

### DIFF
--- a/pkg/apk/implementation.go
+++ b/pkg/apk/implementation.go
@@ -428,7 +428,7 @@ func (a *APK) ResolveWorld(ctx context.Context) (toInstall []*repository.Reposit
 
 	// to fix the world, we need to:
 	// 1. Get the apkIndexes for each repository for the target arch
-	indexes, err := a.getRepositoryIndexes(ctx, a.ignoreSignatures)
+	indexes, err := a.GetRepositoryIndexes(ctx, a.ignoreSignatures)
 	if err != nil {
 		return toInstall, conflicts, fmt.Errorf("error getting repository indexes: %w", err)
 	}
@@ -773,7 +773,7 @@ func (a *APK) expandPackage(ctx context.Context, pkg *repository.RepositoryPacka
 		}
 	}
 
-	rc, err := a.fetchPackage(ctx, pkg)
+	rc, err := a.FetchPackage(ctx, pkg)
 	if err != nil {
 		return nil, fmt.Errorf("fetching package %q: %w", pkg.Name, err)
 	}
@@ -811,7 +811,7 @@ func packageAsURL(pkg *repository.RepositoryPackage) (*url.URL, error) {
 	return url.Parse(string(asURI))
 }
 
-func (a *APK) fetchPackage(ctx context.Context, pkg *repository.RepositoryPackage) (io.ReadCloser, error) {
+func (a *APK) FetchPackage(ctx context.Context, pkg *repository.RepositoryPackage) (io.ReadCloser, error) {
 	a.logger.Debugf("fetching %s (%s)", pkg.Name, pkg.Version)
 
 	ctx, span := otel.Tracer("go-apk").Start(ctx, "fetchPackage", trace.WithAttributes(attribute.String("package", pkg.Name)))

--- a/pkg/apk/implementation_test.go
+++ b/pkg/apk/implementation_test.go
@@ -310,7 +310,7 @@ func TestFetchPackage(t *testing.T) {
 		a.SetClient(&http.Client{
 			Transport: &testLocalTransport{root: testPrimaryPkgDir, basenameOnly: true},
 		})
-		_, err := a.fetchPackage(ctx, pkg)
+		_, err := a.FetchPackage(ctx, pkg)
 		require.NoErrorf(t, err, "unable to install package")
 	})
 	t.Run("cache miss no network", func(t *testing.T) {
@@ -321,7 +321,7 @@ func TestFetchPackage(t *testing.T) {
 		a.SetClient(&http.Client{
 			Transport: &testLocalTransport{fail: true},
 		})
-		_, err := a.fetchPackage(ctx, pkg)
+		_, err := a.FetchPackage(ctx, pkg)
 		require.Error(t, err, "should fail when no cache and no network")
 	})
 	t.Run("cache miss network should fill cache", func(t *testing.T) {
@@ -384,7 +384,7 @@ func TestFetchPackage(t *testing.T) {
 			// use a different root, so we get a different file
 			Transport: &testLocalTransport{root: testAlternatePkgDir, basenameOnly: true, headers: map[string][]string{http.CanonicalHeaderKey("etag"): {testEtag}}},
 		})
-		_, err = a.fetchPackage(ctx, pkg)
+		_, err = a.FetchPackage(ctx, pkg)
 		require.NoErrorf(t, err, "unable to install pkg")
 		// check that the package file is in place
 		_, err = os.Stat(cacheApkFile)
@@ -414,7 +414,7 @@ func TestFetchPackage(t *testing.T) {
 			// use a different root, so we get a different file
 			Transport: &testLocalTransport{root: testAlternatePkgDir, basenameOnly: true, headers: map[string][]string{http.CanonicalHeaderKey("etag"): {testEtag}}},
 		})
-		_, err = a.fetchPackage(ctx, pkg)
+		_, err = a.FetchPackage(ctx, pkg)
 		require.NoErrorf(t, err, "unable to install pkg")
 		// check that the package file is in place
 		_, err = os.Stat(cacheApkFile)
@@ -444,7 +444,7 @@ func TestFetchPackage(t *testing.T) {
 			// use a different root, so we get a different file
 			Transport: &testLocalTransport{root: testAlternatePkgDir, basenameOnly: true, headers: map[string][]string{http.CanonicalHeaderKey("etag"): {testEtag + "abcdefg"}}},
 		})
-		_, err = a.fetchPackage(ctx, pkg)
+		_, err = a.FetchPackage(ctx, pkg)
 		require.NoErrorf(t, err, "unable to install pkg")
 		// check that the package file is in place
 		_, err = os.Stat(cacheApkFile)

--- a/pkg/apk/repo.go
+++ b/pkg/apk/repo.go
@@ -124,9 +124,9 @@ func (a *APK) GetRepositories() (repos []string, err error) {
 	return
 }
 
-// getRepositoryIndexes returns the indexes for the repositories in the specified root.
+// GetRepositoryIndexes returns the indexes for the repositories in the specified root.
 // The signatures for each index are verified unless ignoreSignatures is set to true.
-func (a *APK) getRepositoryIndexes(ctx context.Context, ignoreSignatures bool) ([]NamedIndex, error) {
+func (a *APK) GetRepositoryIndexes(ctx context.Context, ignoreSignatures bool) ([]NamedIndex, error) {
 	ctx, span := otel.Tracer("go-apk").Start(ctx, "getRepositoryIndexes")
 	defer span.End()
 

--- a/pkg/apk/repo_test.go
+++ b/pkg/apk/repo_test.go
@@ -108,7 +108,7 @@ func TestGetRepositoryIndexes(t *testing.T) {
 		a.SetClient(&http.Client{
 			Transport: &testLocalTransport{root: testPrimaryPkgDir, basenameOnly: true},
 		})
-		indexes, err := a.getRepositoryIndexes(context.TODO(), false)
+		indexes, err := a.GetRepositoryIndexes(context.TODO(), false)
 		require.NoErrorf(t, err, "unable to get indexes")
 		require.Greater(t, len(indexes), 0, "no indexes found")
 	})
@@ -120,7 +120,7 @@ func TestGetRepositoryIndexes(t *testing.T) {
 		a.SetClient(&http.Client{
 			Transport: &testLocalTransport{fail: true},
 		})
-		_, err := a.getRepositoryIndexes(context.TODO(), false)
+		_, err := a.GetRepositoryIndexes(context.TODO(), false)
 		require.Error(t, err, "should fail when no cache and no network")
 	})
 	t.Run("we can fetch, but do not cache indices without etag", func(t *testing.T) {
@@ -132,7 +132,7 @@ func TestGetRepositoryIndexes(t *testing.T) {
 		a.SetClient(&http.Client{
 			Transport: &testLocalTransport{root: testPrimaryPkgDir, basenameOnly: true},
 		})
-		indexes, err := a.getRepositoryIndexes(context.TODO(), false)
+		indexes, err := a.GetRepositoryIndexes(context.TODO(), false)
 		require.NoErrorf(t, err, "unable to get indexes")
 		require.Greater(t, len(indexes), 0, "no indexes found")
 
@@ -160,7 +160,7 @@ func TestGetRepositoryIndexes(t *testing.T) {
 				},
 			},
 		})
-		indexes, err := a.getRepositoryIndexes(context.TODO(), false)
+		indexes, err := a.GetRepositoryIndexes(context.TODO(), false)
 		require.NoErrorf(t, err, "unable to get indexes")
 		require.Greater(t, len(indexes), 0, "no indexes found")
 		// check that the contents are the same
@@ -181,7 +181,7 @@ func TestGetRepositoryIndexes(t *testing.T) {
 				requireBasicAuth: true,
 			},
 		})
-		indexes, err := a.getRepositoryIndexes(context.TODO(), false)
+		indexes, err := a.GetRepositoryIndexes(context.TODO(), false)
 		require.NoErrorf(t, err, "unable to get indexes")
 		require.Greater(t, len(indexes), 0, "no indexes found")
 	})
@@ -197,7 +197,7 @@ func TestGetRepositoryIndexes(t *testing.T) {
 			Transport: &testLocalTransport{root: testPrimaryPkgDir, basenameOnly: true, headers: map[string][]string{http.CanonicalHeaderKey("etag"): {testEtag}}},
 		})
 		// Use the client to fill the cache.
-		indexes, err := a.getRepositoryIndexes(context.TODO(), false)
+		indexes, err := a.GetRepositoryIndexes(context.TODO(), false)
 		require.NoErrorf(t, err, "unable to get indexes")
 		require.Greater(t, len(indexes), 0, "no indexes found")
 		// Capture the initial index.
@@ -208,7 +208,7 @@ func TestGetRepositoryIndexes(t *testing.T) {
 		a.SetClient(&http.Client{
 			Transport: &testLocalTransport{root: testAlternatePkgDir, basenameOnly: true, headers: map[string][]string{http.CanonicalHeaderKey("etag"): {testEtag}}},
 		})
-		indexes, err = a.getRepositoryIndexes(context.TODO(), false)
+		indexes, err = a.GetRepositoryIndexes(context.TODO(), false)
 		require.NoErrorf(t, err, "unable to get indexes")
 		require.Greater(t, len(indexes), 0, "no indexes found")
 		// Capture the resulting index.
@@ -229,7 +229,7 @@ func TestGetRepositoryIndexes(t *testing.T) {
 			Transport: &testLocalTransport{root: testPrimaryPkgDir, basenameOnly: true, headers: map[string][]string{http.CanonicalHeaderKey("etag"): {testEtag}}},
 		})
 		// Use the client to fill the cache.
-		indexes, err := a.getRepositoryIndexes(context.TODO(), false)
+		indexes, err := a.GetRepositoryIndexes(context.TODO(), false)
 		require.NoErrorf(t, err, "unable to get indexes")
 		require.Greater(t, len(indexes), 0, "no indexes found")
 		// Capture the initial index.
@@ -241,7 +241,7 @@ func TestGetRepositoryIndexes(t *testing.T) {
 		a.SetClient(&http.Client{
 			Transport: &testLocalTransport{root: testAlternatePkgDir, basenameOnly: true, headers: map[string][]string{http.CanonicalHeaderKey("etag"): {testEtag + "change"}}},
 		})
-		indexes, err = a.getRepositoryIndexes(context.TODO(), false)
+		indexes, err = a.GetRepositoryIndexes(context.TODO(), false)
 		require.NoErrorf(t, err, "unable to get indexes")
 		require.Greater(t, len(indexes), 0, "no indexes found")
 		// Capture the resulting index.
@@ -266,7 +266,7 @@ func TestGetRepositoryIndexes(t *testing.T) {
 						headers:      map[string][]string{http.CanonicalHeaderKey("etag"): {fmt.Sprint(i)}},
 					},
 				})
-				indexes, err := a.getRepositoryIndexes(context.TODO(), false)
+				indexes, err := a.GetRepositoryIndexes(context.TODO(), false)
 				require.NoErrorf(t, err, "unable to get indexes")
 				require.Greater(t, len(indexes), 0, "no indexes found")
 				return nil


### PR DESCRIPTION
Expose GetRepositoryIndexes public, so that they can be re-used for other things than just installing packages.