### PR TITLE
Disable default DEBUG logs

### DIFF
--- a/pkg/apk/implementation.go
+++ b/pkg/apk/implementation.go
@@ -372,7 +372,9 @@ func (a *APK) InitKeyring(ctx context.Context, keyFiles, extraKeyFiles []string)
 			case "https": //nolint:goconst
 				client := a.client
 				if client == nil {
-					client = retryablehttp.NewClient().StandardClient()
+					newClient := retryablehttp.NewClient()
+					newClient.Logger = nil
+					client = newClient.StandardClient()
 				}
 				if a.cache != nil {
 					client = a.cache.client(client, true)
@@ -574,7 +576,9 @@ func (a *APK) fetchAlpineKeys(ctx context.Context, alpineVersions []string) erro
 	u := alpineReleasesURL
 	client := a.client
 	if client == nil {
-		client = retryablehttp.NewClient().StandardClient()
+		newClient := retryablehttp.NewClient()
+		newClient.Logger = nil
+		client = newClient.StandardClient()
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
@@ -837,7 +841,9 @@ func (a *APK) FetchPackage(ctx context.Context, pkg *repository.RepositoryPackag
 	case "https":
 		client := a.client
 		if client == nil {
-			client = retryablehttp.NewClient().StandardClient()
+			newClient := retryablehttp.NewClient()
+			newClient.Logger = nil
+			client = newClient.StandardClient()
 		}
 		if a.cache != nil {
 			client = a.cache.client(client, false)

--- a/pkg/apk/index.go
+++ b/pkg/apk/index.go
@@ -106,7 +106,9 @@ func GetRepositoryIndexes(ctx context.Context, repos []string, keys map[string][
 		case "https":
 			client := opts.httpClient
 			if client == nil {
-				client = retryablehttp.NewClient().StandardClient()
+				newClient := retryablehttp.NewClient()
+				newClient.Logger = nil
+				client = newClient.StandardClient()
 			}
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, asURL.String(), nil)
 			if err != nil {

--- a/pkg/apk/repo.go
+++ b/pkg/apk/repo.go
@@ -166,7 +166,9 @@ func (a *APK) GetRepositoryIndexes(ctx context.Context, ignoreSignatures bool) (
 	}
 	httpClient := a.client
 	if httpClient == nil {
-		httpClient = retryablehttp.NewClient().StandardClient()
+		newClient := retryablehttp.NewClient()
+		newClient.Logger = nil
+		httpClient = newClient.StandardClient()
 	}
 	if a.cache != nil {
 		httpClient = a.cache.client(httpClient, true)


### PR DESCRIPTION
The [go-retryablehttp](https://github.com/hashicorp/go-retryablehttp) library writes debug logs by default: https://github.com/hashicorp/go-retryablehttp/issues/31

Example:
```
2023/09/28 14:39:41 [DEBUG] HEAD https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz
2023/09/28 14:39:41 [DEBUG] GET https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz
```
The recommended way to disable that behaviour is by setting `client.Logger = nil`