### PR TITLE
Add a global cache to dedupe outgoing traffic

### DIFF
--- a/pkg/apk/repo_test.go
+++ b/pkg/apk/repo_test.go
@@ -113,6 +113,9 @@ func TestGetRepositoryIndexes(t *testing.T) {
 		require.Greater(t, len(indexes), 0, "no indexes found")
 	})
 	t.Run("cache miss no network", func(t *testing.T) {
+		// Reset etag cache so we have isolated tests.
+		globalCache = &etagCache{}
+
 		// we use a transport that always returns a 404 so we know we're not hitting the network
 		// it should fail for a cache hit
 		tmpDir := t.TempDir()
@@ -124,6 +127,9 @@ func TestGetRepositoryIndexes(t *testing.T) {
 		require.Error(t, err, "should fail when no cache and no network")
 	})
 	t.Run("we can fetch, but do not cache indices without etag", func(t *testing.T) {
+		// Reset etag cache so we have isolated tests.
+		globalCache = &etagCache{}
+
 		// we use a transport that can read from the network
 		// it should fail for a cache hit
 		tmpDir := t.TempDir()
@@ -144,6 +150,9 @@ func TestGetRepositoryIndexes(t *testing.T) {
 		}))
 	})
 	t.Run("cache miss network should fill cache", func(t *testing.T) {
+		// Reset etag cache so we have isolated tests.
+		globalCache = &etagCache{}
+
 		// we use a transport that can read from the network
 		// it should fail for a cache hit
 		tmpDir := t.TempDir()
@@ -171,6 +180,9 @@ func TestGetRepositoryIndexes(t *testing.T) {
 		require.Equal(t, index1, index2, "index files do not match")
 	})
 	t.Run("repo url with http basic auth", func(t *testing.T) {
+		// Reset etag cache so we have isolated tests.
+		globalCache = &etagCache{}
+
 		tmpDir := t.TempDir()
 		a := prepLayout(t, tmpDir, []string{"https://user:pass@dl-cdn.alpinelinux.org/alpine/v3.16/main"})
 
@@ -186,6 +198,9 @@ func TestGetRepositoryIndexes(t *testing.T) {
 		require.Greater(t, len(indexes), 0, "no indexes found")
 	})
 	t.Run("cache hit etag match", func(t *testing.T) {
+		// Reset etag cache so we have isolated tests.
+		globalCache = &etagCache{}
+
 		// it should succeed for a cache hit
 		tmpDir := t.TempDir()
 		testEtag := "test-etag"
@@ -218,6 +233,9 @@ func TestGetRepositoryIndexes(t *testing.T) {
 		require.Equal(t, index1, index2, "index files do not match")
 	})
 	t.Run("cache hit etag miss", func(t *testing.T) {
+		// Reset etag cache so we have isolated tests.
+		globalCache = &etagCache{}
+
 		// it should succeed for a cache hit
 		tmpDir := t.TempDir()
 		testEtag := "test-etag"
@@ -241,6 +259,10 @@ func TestGetRepositoryIndexes(t *testing.T) {
 		a.SetClient(&http.Client{
 			Transport: &testLocalTransport{root: testAlternatePkgDir, basenameOnly: true, headers: map[string][]string{http.CanonicalHeaderKey("etag"): {testEtag + "change"}}},
 		})
+
+		// Reset etag cache.
+		globalCache = &etagCache{}
+
 		indexes, err = a.GetRepositoryIndexes(context.TODO(), false)
 		require.NoErrorf(t, err, "unable to get indexes")
 		require.Greater(t, len(indexes), 0, "no indexes found")
@@ -251,6 +273,9 @@ func TestGetRepositoryIndexes(t *testing.T) {
 		require.NotEqual(t, index1, index2, "index files do not match")
 	})
 	t.Run("test cache concurrency", func(t *testing.T) {
+		// Reset etag cache so we have isolated tests.
+		globalCache = &etagCache{}
+
 		// Use the same temp directory for the cache.
 		tmpDir := t.TempDir()
 

--- a/pkg/apk/transport.go
+++ b/pkg/apk/transport.go
@@ -91,7 +91,11 @@ func (r *rangeRetryReader) reset(oerr error) (*http.Response, error) {
 			}
 		}
 	} else if resp.StatusCode != http.StatusPartialContent {
-		return resp, fmt.Errorf("retrying %w: %s %s (Range: %s): unexpected status code: %d", oerr, req.Method, req.URL.String(), rangeHeader, resp.StatusCode)
+		if oerr != nil {
+			return resp, fmt.Errorf("retrying %w: %s %s (Range: %s): unexpected status code: %d", oerr, req.Method, req.URL.String(), rangeHeader, resp.StatusCode)
+		}
+
+		return resp, fmt.Errorf("%s %s (Range: %s): unexpected status code: %d", req.Method, req.URL.String(), rangeHeader, resp.StatusCode)
 	}
 
 	r.body = resp.Body


### PR DESCRIPTION
This is not great but is the simplest way to send way fewer outgoing requests for each key and index.