### PR TITLE
Add global parsed index cache

### DIFF
--- a/pkg/apk/cache.go
+++ b/pkg/apk/cache.go
@@ -30,7 +30,7 @@ import (
 // This is terrible but simpler than plumbing around a cache for now.
 // We will assume that for a given process, we want to reuse etag values.
 // Doing this cuts down on the number of requests we send for index and keys.
-var globalCache = &etagCache{}
+var globalEtagCache = &etagCache{}
 
 type etagResp struct {
 	resp      *http.Response
@@ -225,7 +225,7 @@ func (t *cacheTransport) RoundTrip(request *http.Request) (*http.Response, error
 		}, nil
 	}
 
-	return globalCache.get(t, request, cacheFile)
+	return globalEtagCache.get(t, request, cacheFile)
 }
 
 func cacheDirFromFile(cacheFile string) string {

--- a/pkg/apk/index.go
+++ b/pkg/apk/index.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/klauspost/compress/gzip"
 
@@ -39,6 +40,68 @@ import (
 
 var signatureFileRegex = regexp.MustCompile(`^\.SIGN\.RSA\.(.*\.rsa\.pub)$`)
 
+// This is terrible but simpler than plumbing around a cache for now.
+// We just hold the parsed index in memory rather than re-parsing it every time,
+// which requires gunzipping, which is (somewhat) expensive.
+var globalIndexCache = &indexCache{}
+
+type indexResult struct {
+	idx *repository.ApkIndex
+	err error
+}
+
+type indexCache struct {
+	// repoBase -> *sync.Once
+	onces sync.Map
+
+	// repoBase -> indexResult
+	indexes sync.Map
+}
+
+func (i *indexCache) get(ctx context.Context, repo string, keys map[string][]byte, arch string, opts *indexOpts) (NamedIndex, error) {
+	// does it start with a pin?
+	var (
+		repoName string
+		repoURL  = repo
+	)
+	if strings.HasPrefix(repo, "@") {
+		// it's a pinned repository, get the name
+		parts := strings.Fields(repo)
+		if len(parts) < 2 {
+			return nil, fmt.Errorf("invalid repository line: %q", repo)
+		}
+		repoName = parts[0][1:]
+		repoURL = parts[1]
+	}
+
+	u := IndexURL(repoURL, arch)
+	repoBase := fmt.Sprintf("%s/%s", repoURL, arch)
+
+	// Do all the expensive things inside the once.
+	once, _ := i.onces.LoadOrStore(u, &sync.Once{})
+	once.(*sync.Once).Do(func() {
+		idx, err := getRepositoryIndex(ctx, u, keys, arch, opts)
+		i.indexes.Store(u, indexResult{
+			idx: idx,
+			err: err,
+		})
+	})
+
+	v, ok := i.indexes.Load(u)
+	if !ok {
+		panic(fmt.Errorf("did not see index %q after writing it", u))
+	}
+	result := v.(indexResult)
+
+	index, err := result.idx, result.err
+	if err != nil {
+		return nil, err
+	}
+
+	repoRef := repository.Repository{Uri: repoBase}
+	return NewNamedRepositoryWithIndex(repoName, repoRef.WithIndex(index)), nil
+}
+
 // IndexURL full URL to the index file for the given repo and arch
 func IndexURL(repo, arch string) string {
 	return fmt.Sprintf("%s/%s/%s", repo, arch, indexFilename)
@@ -48,7 +111,7 @@ func IndexURL(repo, arch string) string {
 // The signatures for each index are verified unless ignoreSignatures is set to true.
 // The key-value pairs in the map for `keys` are the name of the key and the contents of the key.
 // The name is just indicative. If it finds a match, it will use it. Else, it will try all keys.
-func GetRepositoryIndexes(ctx context.Context, repos []string, keys map[string][]byte, arch string, options ...IndexOption) (indexes []NamedIndex, err error) { //nolint:gocyclo
+func GetRepositoryIndexes(ctx context.Context, repos []string, keys map[string][]byte, arch string, options ...IndexOption) (indexes []NamedIndex, err error) {
 	ctx, span := otel.Tracer("go-apk").Start(ctx, "GetRepositoryIndexes")
 	defer span.End()
 
@@ -58,166 +121,163 @@ func GetRepositoryIndexes(ctx context.Context, repos []string, keys map[string][
 	}
 
 	for _, repo := range repos {
-		// does it start with a pin?
-		var (
-			repoName string
-			repoURL  = repo
-		)
-		if strings.HasPrefix(repo, "@") {
-			// it's a pinned repository, get the name
-			parts := strings.Fields(repo)
-			if len(parts) < 2 {
-				return nil, errors.New("invalid repository line")
-			}
-			repoName = parts[0][1:]
-			repoURL = parts[1]
-		}
-
-		repoBase := fmt.Sprintf("%s/%s", repoURL, arch)
-		u := IndexURL(repoURL, arch)
-
-		// Normalize the repo as a URI, so that local paths
-		// are translated into file:// URLs, allowing them to be parsed
-		// into a url.URL{}.
-		var (
-			b     []byte
-			asURL *url.URL
-		)
-		if strings.HasPrefix(u, "https://") {
-			asURL, err = url.Parse(u)
-		} else {
-			// Attempt to parse non-https elements into URI's so they are translated into
-			// file:// URLs allowing them to parse into a url.URL{}
-			asURL, err = url.Parse(string(uri.New(u)))
-		}
+		index, err := globalIndexCache.get(ctx, repo, keys, arch, opts)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse repo as URI: %w", err)
+			return nil, err
 		}
 
-		switch asURL.Scheme {
-		case "file":
-			b, err = os.ReadFile(u)
-			if err != nil {
-				if !errors.Is(err, fs.ErrNotExist) {
-					return nil, fmt.Errorf("failed to read repository %s: %w", u, err)
-				}
-				continue
-			}
-		case "https":
-			client := opts.httpClient
-			if client == nil {
-				client = retryablehttp.NewClient().StandardClient()
-			}
-			req, err := http.NewRequestWithContext(ctx, http.MethodGet, asURL.String(), nil)
-			if err != nil {
-				return nil, err
-			}
-			// if the repo URL contains HTTP Basic Auth credentials, add them to the request
-			if asURL.User != nil {
-				user := asURL.User.Username()
-				pass, _ := asURL.User.Password()
-				req.SetBasicAuth(user, pass)
-			}
-
-			// This will return a body that retries requests using Range requests if Read() hits an error.
-			rrt := newRangeRetryTransport(ctx, client)
-			res, err := rrt.RoundTrip(req)
-			if err != nil {
-				return nil, fmt.Errorf("unable to get repository index at %s: %w", u, err)
-			}
-			switch res.StatusCode {
-			case http.StatusOK:
-				// this is fine
-			case http.StatusNotFound:
-				return nil, fmt.Errorf("repository index not found for architecture %s at %s", arch, u)
-			default:
-				return nil, fmt.Errorf("unexpected status code %d when getting repository index for architecture %s at %s", res.StatusCode, arch, u)
-			}
-			defer res.Body.Close()
-			buf := bytes.NewBuffer(nil)
-			if _, err := io.Copy(buf, res.Body); err != nil {
-				return nil, fmt.Errorf("unable to read repository index at %s: %w", u, err)
-			}
-			b = buf.Bytes()
-		default:
-			return nil, fmt.Errorf("repository scheme %s not supported", asURL.Scheme)
+		// Can happen for fs.ErrNotExist in file scheme, we just ignore it.
+		if index == nil {
+			continue
 		}
 
-		// validate the signature
-		if !opts.ignoreSignatures {
-			buf := bytes.NewReader(b)
-			gzipReader, err := gzip.NewReader(buf)
-			if err != nil {
-				return nil, fmt.Errorf("unable to create gzip reader for repository index: %w", err)
-			}
-			// set multistream to false, so we can read each part separately;
-			// the first part is the signature, the second is the index, which should be
-			// verified.
-			gzipReader.Multistream(false)
-			defer gzipReader.Close()
-
-			tarReader := tar.NewReader(gzipReader)
-
-			// read the signature
-			signatureFile, err := tarReader.Next()
-			if err != nil {
-				return nil, fmt.Errorf("failed to read signature from repository index: %w", err)
-			}
-			matches := signatureFileRegex.FindStringSubmatch(signatureFile.Name)
-			if len(matches) != 2 {
-				return nil, fmt.Errorf("failed to find key name in signature file name: %s", signatureFile.Name)
-			}
-			signature, err := io.ReadAll(tarReader)
-			if err != nil {
-				return nil, fmt.Errorf("failed to read signature from repository index: %w", err)
-			}
-			// with multistream false, we should read the next one
-			if _, err := tarReader.Next(); err != nil && !errors.Is(err, io.EOF) {
-				return nil, fmt.Errorf("unexpected error reading from tgz: %w", err)
-			}
-			// we now have the signature bytes and name, get the contents of the rest;
-			// this should be everything else in the raw gzip file as is.
-			allBytes := len(b)
-			unreadBytes := buf.Len()
-			readBytes := allBytes - unreadBytes
-			indexData := b[readBytes:]
-
-			indexDigest, err := sign.HashData(indexData)
-			if err != nil {
-				return nil, err
-			}
-			// now we can check the signature
-			if keys == nil {
-				return nil, fmt.Errorf("no keys provided to verify signature")
-			}
-			var verified bool
-			keyData, ok := keys[matches[1]]
-			if ok {
-				if err := sign.RSAVerifySHA1Digest(indexDigest, signature, keyData); err != nil {
-					verified = false
-				}
-			}
-			if !verified {
-				for _, keyData := range keys {
-					if err := sign.RSAVerifySHA1Digest(indexDigest, signature, keyData); err == nil {
-						verified = true
-						break
-					}
-				}
-			}
-			if !verified {
-				return nil, fmt.Errorf("no key found to verify signature for keyfile %s; tried all other keys as well", matches[1])
-			}
-		}
-		// with a valid signature, convert it to an ApkIndex
-		index, err := repository.IndexFromArchive(io.NopCloser(bytes.NewReader(b)))
-		if err != nil {
-			return nil, fmt.Errorf("unable to read convert repository index bytes to index struct at %s: %w", u, err)
-		}
-		repoRef := repository.Repository{Uri: repoBase}
-		indexes = append(indexes, NewNamedRepositoryWithIndex(repoName, repoRef.WithIndex(index)))
+		indexes = append(indexes, index)
 	}
 	return indexes, nil
+}
+
+func getRepositoryIndex(ctx context.Context, u string, keys map[string][]byte, arch string, opts *indexOpts) (*repository.ApkIndex, error) {
+	// Normalize the repo as a URI, so that local paths
+	// are translated into file:// URLs, allowing them to be parsed
+	// into a url.URL{}.
+	var (
+		b     []byte
+		asURL *url.URL
+		err   error
+	)
+	if strings.HasPrefix(u, "https://") {
+		asURL, err = url.Parse(u)
+	} else {
+		// Attempt to parse non-https elements into URI's so they are translated into
+		// file:// URLs allowing them to parse into a url.URL{}
+		asURL, err = url.Parse(string(uri.New(u)))
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse repo as URI: %w", err)
+	}
+
+	switch asURL.Scheme {
+	case "file":
+		b, err = os.ReadFile(u)
+		if err != nil {
+			if !errors.Is(err, fs.ErrNotExist) {
+				return nil, fmt.Errorf("failed to read repository %s: %w", u, err)
+			}
+			return nil, nil
+		}
+	case "https":
+		client := opts.httpClient
+		if client == nil {
+			client = retryablehttp.NewClient().StandardClient()
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, asURL.String(), nil)
+		if err != nil {
+			return nil, err
+		}
+		// if the repo URL contains HTTP Basic Auth credentials, add them to the request
+		if asURL.User != nil {
+			user := asURL.User.Username()
+			pass, _ := asURL.User.Password()
+			req.SetBasicAuth(user, pass)
+		}
+
+		// This will return a body that retries requests using Range requests if Read() hits an error.
+		rrt := newRangeRetryTransport(ctx, client)
+		res, err := rrt.RoundTrip(req)
+		if err != nil {
+			return nil, fmt.Errorf("unable to get repository index at %s: %w", u, err)
+		}
+		switch res.StatusCode {
+		case http.StatusOK:
+			// this is fine
+		case http.StatusNotFound:
+			return nil, fmt.Errorf("repository index not found for architecture %s at %s", arch, u)
+		default:
+			return nil, fmt.Errorf("unexpected status code %d when getting repository index for architecture %s at %s", res.StatusCode, arch, u)
+		}
+		defer res.Body.Close()
+		buf := bytes.NewBuffer(nil)
+		if _, err := io.Copy(buf, res.Body); err != nil {
+			return nil, fmt.Errorf("unable to read repository index at %s: %w", u, err)
+		}
+		b = buf.Bytes()
+	default:
+		return nil, fmt.Errorf("repository scheme %s not supported", asURL.Scheme)
+	}
+
+	// validate the signature
+	if !opts.ignoreSignatures {
+		buf := bytes.NewReader(b)
+		gzipReader, err := gzip.NewReader(buf)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create gzip reader for repository index: %w", err)
+		}
+		// set multistream to false, so we can read each part separately;
+		// the first part is the signature, the second is the index, which should be
+		// verified.
+		gzipReader.Multistream(false)
+		defer gzipReader.Close()
+
+		tarReader := tar.NewReader(gzipReader)
+
+		// read the signature
+		signatureFile, err := tarReader.Next()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read signature from repository index: %w", err)
+		}
+		matches := signatureFileRegex.FindStringSubmatch(signatureFile.Name)
+		if len(matches) != 2 {
+			return nil, fmt.Errorf("failed to find key name in signature file name: %s", signatureFile.Name)
+		}
+		signature, err := io.ReadAll(tarReader)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read signature from repository index: %w", err)
+		}
+		// with multistream false, we should read the next one
+		if _, err := tarReader.Next(); err != nil && !errors.Is(err, io.EOF) {
+			return nil, fmt.Errorf("unexpected error reading from tgz: %w", err)
+		}
+		// we now have the signature bytes and name, get the contents of the rest;
+		// this should be everything else in the raw gzip file as is.
+		allBytes := len(b)
+		unreadBytes := buf.Len()
+		readBytes := allBytes - unreadBytes
+		indexData := b[readBytes:]
+
+		indexDigest, err := sign.HashData(indexData)
+		if err != nil {
+			return nil, err
+		}
+		// now we can check the signature
+		if keys == nil {
+			return nil, fmt.Errorf("no keys provided to verify signature")
+		}
+		var verified bool
+		keyData, ok := keys[matches[1]]
+		if ok {
+			if err := sign.RSAVerifySHA1Digest(indexDigest, signature, keyData); err != nil {
+				verified = false
+			}
+		}
+		if !verified {
+			for _, keyData := range keys {
+				if err := sign.RSAVerifySHA1Digest(indexDigest, signature, keyData); err == nil {
+					verified = true
+					break
+				}
+			}
+		}
+		if !verified {
+			return nil, fmt.Errorf("no key found to verify signature for keyfile %s; tried all other keys as well", matches[1])
+		}
+	}
+	// with a valid signature, convert it to an ApkIndex
+	index, err := repository.IndexFromArchive(io.NopCloser(bytes.NewReader(b)))
+	if err != nil {
+		return nil, fmt.Errorf("unable to read convert repository index bytes to index struct at %s: %w", u, err)
+	}
+
+	return index, err
 }
 
 type indexOpts struct {

--- a/pkg/apk/repo_test.go
+++ b/pkg/apk/repo_test.go
@@ -114,7 +114,7 @@ func TestGetRepositoryIndexes(t *testing.T) {
 	})
 	t.Run("cache miss no network", func(t *testing.T) {
 		// Reset etag cache so we have isolated tests.
-		globalCache = &etagCache{}
+		globalEtagCache, globalIndexCache = &etagCache{}, &indexCache{}
 
 		// we use a transport that always returns a 404 so we know we're not hitting the network
 		// it should fail for a cache hit
@@ -128,7 +128,7 @@ func TestGetRepositoryIndexes(t *testing.T) {
 	})
 	t.Run("we can fetch, but do not cache indices without etag", func(t *testing.T) {
 		// Reset etag cache so we have isolated tests.
-		globalCache = &etagCache{}
+		globalEtagCache, globalIndexCache = &etagCache{}, &indexCache{}
 
 		// we use a transport that can read from the network
 		// it should fail for a cache hit
@@ -151,7 +151,7 @@ func TestGetRepositoryIndexes(t *testing.T) {
 	})
 	t.Run("cache miss network should fill cache", func(t *testing.T) {
 		// Reset etag cache so we have isolated tests.
-		globalCache = &etagCache{}
+		globalEtagCache, globalIndexCache = &etagCache{}, &indexCache{}
 
 		// we use a transport that can read from the network
 		// it should fail for a cache hit
@@ -181,7 +181,7 @@ func TestGetRepositoryIndexes(t *testing.T) {
 	})
 	t.Run("repo url with http basic auth", func(t *testing.T) {
 		// Reset etag cache so we have isolated tests.
-		globalCache = &etagCache{}
+		globalEtagCache = &etagCache{}
 
 		tmpDir := t.TempDir()
 		a := prepLayout(t, tmpDir, []string{"https://user:pass@dl-cdn.alpinelinux.org/alpine/v3.16/main"})
@@ -199,7 +199,7 @@ func TestGetRepositoryIndexes(t *testing.T) {
 	})
 	t.Run("cache hit etag match", func(t *testing.T) {
 		// Reset etag cache so we have isolated tests.
-		globalCache = &etagCache{}
+		globalEtagCache = &etagCache{}
 
 		// it should succeed for a cache hit
 		tmpDir := t.TempDir()
@@ -234,7 +234,7 @@ func TestGetRepositoryIndexes(t *testing.T) {
 	})
 	t.Run("cache hit etag miss", func(t *testing.T) {
 		// Reset etag cache so we have isolated tests.
-		globalCache = &etagCache{}
+		globalEtagCache, globalIndexCache = &etagCache{}, &indexCache{}
 
 		// it should succeed for a cache hit
 		tmpDir := t.TempDir()
@@ -261,7 +261,7 @@ func TestGetRepositoryIndexes(t *testing.T) {
 		})
 
 		// Reset etag cache.
-		globalCache = &etagCache{}
+		globalEtagCache, globalIndexCache = &etagCache{}, &indexCache{}
 
 		indexes, err = a.GetRepositoryIndexes(context.TODO(), false)
 		require.NoErrorf(t, err, "unable to get indexes")
@@ -274,7 +274,7 @@ func TestGetRepositoryIndexes(t *testing.T) {
 	})
 	t.Run("test cache concurrency", func(t *testing.T) {
 		// Reset etag cache so we have isolated tests.
-		globalCache = &etagCache{}
+		globalEtagCache = &etagCache{}
 
 		// Use the same temp directory for the cache.
 		tmpDir := t.TempDir()


### PR DESCRIPTION
This dedupes parsing the index (and the index itself) so we aren't parsing the same index over and over again (and holding a bunch of copies in memory).

Again, not the best, but this is the second of three things we're going to dedupe in-process like this, mostly for the terraform provider, which does a lot of simultaneous work that is very very similar and amenable to this kind of deduplication.