### PR TITLE
Provide a means to access the control segment with APKFS.

### DIFF
--- a/pkg/fs/apkfs_test.go
+++ b/pkg/fs/apkfs_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestReadAPKFile(t *testing.T) {
 	t.Run("stat", func(t *testing.T) {
-		apkfs, err := NewAPKFS(context.Background(), "testdata/hello-2.12-r0.apk")
+		apkfs, err := NewAPKFS(context.Background(), "testdata/hello-2.12-r0.apk", APKFSPackage)
 		require.Nil(t, err)
 		defer apkfs.Close()
 		require.NotNil(t, apkfs)
@@ -22,7 +22,7 @@ func TestReadAPKFile(t *testing.T) {
 		require.Equal(t, info.Name(), "hello")
 	})
 	t.Run("read", func(t *testing.T) {
-		apkfs, err := NewAPKFS(context.Background(), "testdata/hello-2.12-r0.apk")
+		apkfs, err := NewAPKFS(context.Background(), "testdata/hello-2.12-r0.apk", APKFSPackage)
 		require.Nil(t, err)
 		defer apkfs.Close()
 		require.NotNil(t, apkfs)


### PR DESCRIPTION
Add a parameter to specify whether or not the apkfs object should operate on the control segment or the package segment