### PR TITLE
Fix tar header sorting

### DIFF
--- a/pkg/apk/installed.go
+++ b/pkg/apk/installed.go
@@ -422,10 +422,11 @@ func parseInstalledPerms(permString string) (uid, gid int, perms int64, err erro
 	return
 }
 
-// sortTarHeaders sorts tar headers by name. It ensures that all file children of a directory are listed
-// immediately after the directory itself. This is to support lib/apk/db/installed, which lists full paths
-// for directories, but only the basename for the files, so the last directory entry before a file must be the parent
-// in which it sits.
+// sortTarHeaders sorts tar headers by name. It ensures that all file children
+// of a directory are listed immediately after the directory itself. This is to
+// support lib/apk/db/installed, which lists full paths for directories, but
+// only the basename for the files, so the last directory entry before a file
+// must be the parent in which it sits.
 func sortTarHeaders(headers []tar.Header) []tar.Header {
 	var (
 		// Create a tree with everything in it, where keys are full directory paths,
@@ -437,9 +438,12 @@ func sortTarHeaders(headers []tar.Header) []tar.Header {
 	)
 
 	for _, header := range headers {
-		dir := filepath.Dir(header.Name)
-		directoryChildren[dir] = append(directoryChildren[dir], header.Name)
-		all[header.Name] = header
+		// Use a cleaned name for map keys to ensure consistency with lookups later.
+		cleanedName := filepath.Clean(header.Name)
+
+		dir := filepath.Dir(cleanedName)
+		directoryChildren[dir] = append(directoryChildren[dir], cleanedName)
+		all[cleanedName] = header
 	}
 
 	// Map the directory entries (the keys in "directoryChildren") to a slice (and
@@ -463,7 +467,6 @@ func sortTarHeaders(headers []tar.Header) []tar.Header {
 
 	sorted := sortChildrenTarHeaders(directoryChildren, all, topLevelDirs)
 	return sorted
-
 }
 
 func sortChildrenTarHeaders(directoryChildren map[string][]string, all map[string]tar.Header, children []string) []tar.Header {

--- a/pkg/apk/installed.go
+++ b/pkg/apk/installed.go
@@ -427,92 +427,79 @@ func parseInstalledPerms(permString string) (uid, gid int, perms int64, err erro
 // for directories, but only the basename for the files, so the last directory entry before a file must be the parent
 // in which it sits.
 func sortTarHeaders(headers []tar.Header) []tar.Header {
-	// to hold our results
 	var (
-		sorted = make([]tar.Header, 0, len(headers))
-		// create a tree with everything in it, where keys are full directory paths, values are slice of full paths of children
-		listing = map[string][]string{}
-		all     = map[string]tar.Header{}
+		// Create a tree with everything in it, where keys are full directory paths,
+		// values are slice of full paths of children. (Every directory in the tree will
+		// have its own key in the map.)
+		directoryChildren = map[string][]string{}
+
+		all = map[string]tar.Header{}
 	)
 
 	for _, header := range headers {
 		dir := filepath.Dir(header.Name)
-		listing[dir] = append(listing[dir], header.Name)
+		directoryChildren[dir] = append(directoryChildren[dir], header.Name)
 		all[header.Name] = header
 	}
-	// now we have a map where the keys are all of the directories, and the values are all of the files or directories
-	// in that directory
-	// now we can build the structure
-	var dirEntries = make([]string, 0, len(listing))
-	for entry := range listing {
-		dirEntries = append(dirEntries, entry)
+
+	// Map the directory entries (the keys in "directoryChildren") to a slice (and
+	// sort them for determinism).
+	var dirEntries = make([]string, 0, len(directoryChildren))
+	for dir := range directoryChildren {
+		dirEntries = append(dirEntries, dir)
 	}
-	sort.Slice(dirEntries, func(i, j int) bool {
-		return dirEntries[i] < dirEntries[j]
-	})
-	// go through each directory entry.
-	// add the directory itsef, then add its file children
+	sort.Strings(dirEntries)
+
+	// We'll start with top-level directories, and then descend into their children
+	// recursively.
+	var topLevelDirs = make([]string, 0, len(dirEntries))
 	for _, dir := range dirEntries {
-		header, ok := all[dir]
+		if filepath.Dir(dir) == "." {
+			topLevelDirs = append(topLevelDirs, dir)
+		}
+	}
+
+	sort.Strings(topLevelDirs)
+
+	sorted := sortChildrenTarHeaders(directoryChildren, all, topLevelDirs)
+	return sorted
+
+}
+
+func sortChildrenTarHeaders(directoryChildren map[string][]string, all map[string]tar.Header, children []string) []tar.Header {
+	sort.Strings(children)
+
+	// Non-directory type files need to be first.
+	var sorted = make([]tar.Header, 0, len(children))
+	for _, child := range children {
+		header, ok := all[child]
 		if !ok {
 			continue
 		}
-		sorted = append(sorted, header)
-		// now all of its children
-		children, ok := listing[dir]
-		if !ok || len(children) == 0 {
-			continue
-		}
-		sort.Strings(children)
-		for _, child := range children {
-			header, ok := all[child]
-			if !ok || header.Typeflag == tar.TypeDir {
-				continue
-			}
+		if header.Typeflag != tar.TypeDir {
 			sorted = append(sorted, header)
 		}
 	}
-	/*
-		sort.Slice(headers, func(i, j int) bool {
-			parentDirI, parentDirJ := filepath.Dir(headers[i].Name), filepath.Dir(headers[j].Name)
-			isDirI, isDirJ := headers[i].Typeflag == tar.TypeDir, headers[j].Typeflag == tar.TypeDir
 
-			// logic is somewhat complicated.
-			// If the two paths are in the same directory, then files before dirs, then sort by name
-			if parentDirI == parentDirJ {
-				if isDirI == isDirJ {
-					return headers[i].Name < headers[j].Name
-				}
-				if isDirI {
-					return false
-				}
-				return true
-			}
-			// the two are not in the same directory
+	// Then directories.
+	for _, child := range children {
+		header, ok := all[child]
+		if !ok {
+			continue
+		}
+		if header.Typeflag == tar.TypeDir {
+			sorted = append(sorted, header)
 
-			// If both are files, then sort by name
-			// If both are directories, then sort by name. This will put parents before their children automatically,
-			// which we need as well
-			if isDirI == isDirJ {
-				return headers[i].Name < headers[j].Name
+			// And their children.
+			children, ok := directoryChildren[child]
+			if !ok || len(children) == 0 {
+				continue
 			}
 
-			// one is a directory, one is a file
-			// see if the file is in the directory; if so, the directory comes first
-			if isDirI {
-				if strings.HasPrefix(headers[j].Name, parentDirI) {
-					return true
-				}
-				// file is not a child of the directory, direct or otherwise.
-				//
-			}
-			if isDirJ {
-				if strings.HasPrefix(headers[i].Name, parentDirJ) {
-					return false
-				}
-			}
+			sortedChildren := sortChildrenTarHeaders(directoryChildren, all, children)
+			sorted = append(sorted, sortedChildren...)
+		}
+	}
 
-		})
-	*/
 	return sorted
 }

--- a/pkg/apk/installed_test.go
+++ b/pkg/apk/installed_test.go
@@ -317,9 +317,13 @@ func TestSortTarHeaders(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			results := sortTarHeaders(tt.headers)
-			for i, header := range results {
-				assert.Equal(t, tt.expected[i], header.Name, "position %d: expected %s, got %s", i, tt.expected[i], header.Name)
+
+			var resultHeaderNames []string
+			for _, header := range results {
+				resultHeaderNames = append(resultHeaderNames, header.Name)
 			}
+
+			assert.Equal(t, tt.expected, resultHeaderNames)
 		})
 	}
 }

--- a/pkg/apk/installed_test.go
+++ b/pkg/apk/installed_test.go
@@ -276,36 +276,50 @@ func TestUpdateTriggers(t *testing.T) {
 }
 
 func TestSortTarHeaders(t *testing.T) {
-	headers := []tar.Header{
-		{Name: "bin", Typeflag: tar.TypeDir},
-		{Name: "usr", Typeflag: tar.TypeDir},
-		{Name: "usr/etc", Typeflag: tar.TypeDir},
-		{Name: "usr/bin", Typeflag: tar.TypeDir},
-		{Name: "bin/ls", Typeflag: tar.TypeReg},
-		{Name: "bin/busybox"},
-		{Name: "etc", Typeflag: tar.TypeDir},
-		{Name: "etc/logrotate.d", Typeflag: tar.TypeDir},
-		{Name: "etc/logrotate.d/file", Typeflag: tar.TypeReg},
-		{Name: "etc/logrotate.d/file2", Typeflag: tar.TypeReg},
-		{Name: "etc/hosts", Typeflag: tar.TypeReg},
-		{Name: "etc/mylaterfile", Typeflag: tar.TypeReg}, // this is particularly good for testing that it comes before logrotate.d
+	cases := []struct {
+		name     string
+		headers  []tar.Header
+		expected []string
+	}{
+		{
+			name: "normal",
+			headers: []tar.Header{
+				{Name: "bin", Typeflag: tar.TypeDir},
+				{Name: "usr", Typeflag: tar.TypeDir},
+				{Name: "usr/etc", Typeflag: tar.TypeDir},
+				{Name: "usr/bin", Typeflag: tar.TypeDir},
+				{Name: "bin/ls", Typeflag: tar.TypeReg},
+				{Name: "bin/busybox"},
+				{Name: "etc", Typeflag: tar.TypeDir},
+				{Name: "etc/logrotate.d", Typeflag: tar.TypeDir},
+				{Name: "etc/logrotate.d/file", Typeflag: tar.TypeReg},
+				{Name: "etc/logrotate.d/file2", Typeflag: tar.TypeReg},
+				{Name: "etc/hosts", Typeflag: tar.TypeReg},
+				{Name: "etc/mylaterfile", Typeflag: tar.TypeReg}, // this is particularly good for testing that it comes before logrotate.d
+			},
+			expected: []string{
+				"bin",
+				"bin/busybox",
+				"bin/ls",
+				"etc",
+				"etc/hosts",
+				"etc/mylaterfile",
+				"etc/logrotate.d",
+				"etc/logrotate.d/file",
+				"etc/logrotate.d/file2",
+				"usr",
+				"usr/etc",
+				"usr/bin",
+			},
+		},
 	}
-	expected := []string{
-		"bin",
-		"bin/busybox",
-		"bin/ls",
-		"etc",
-		"etc/hosts",
-		"etc/mylaterfile",
-		"etc/logrotate.d",
-		"etc/logrotate.d/file",
-		"etc/logrotate.d/file2",
-		"usr",
-		"usr/etc",
-		"usr/bin",
-	}
-	results := sortTarHeaders(headers)
-	for i, header := range results {
-		assert.Equal(t, expected[i], header.Name, "position %d: expected %s, got %s", i, expected[i], header.Name)
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			results := sortTarHeaders(tt.headers)
+			for i, header := range results {
+				assert.Equal(t, tt.expected[i], header.Name, "position %d: expected %s, got %s", i, tt.expected[i], header.Name)
+			}
+		})
 	}
 }

--- a/pkg/apk/installed_test.go
+++ b/pkg/apk/installed_test.go
@@ -335,8 +335,8 @@ func TestSortTarHeaders(t *testing.T) {
 				{Name: "usr/bin/cmd", Typeflag: tar.TypeReg},
 			},
 			expected: []string{
-				"usr",
-				"usr/bin",
+				"usr/",
+				"usr/bin/",
 				"usr/bin/cmd",
 			},
 		},

--- a/pkg/apk/installed_test.go
+++ b/pkg/apk/installed_test.go
@@ -308,8 +308,8 @@ func TestSortTarHeaders(t *testing.T) {
 				"etc/logrotate.d/file",
 				"etc/logrotate.d/file2",
 				"usr",
-				"usr/etc",
 				"usr/bin",
+				"usr/etc",
 			},
 		},
 	}

--- a/pkg/apk/installed_test.go
+++ b/pkg/apk/installed_test.go
@@ -312,6 +312,34 @@ func TestSortTarHeaders(t *testing.T) {
 				"usr/etc",
 			},
 		},
+		{
+			name: "intermediate dirs in the tree should be required to preserve children",
+			headers: []tar.Header{
+				{Name: "usr", Typeflag: tar.TypeDir},
+				{Name: "usr/bin", Typeflag: tar.TypeDir},
+				{Name: "etc", Typeflag: tar.TypeDir},
+				{Name: "etc/logrotate.d/file", Typeflag: tar.TypeReg},
+				{Name: "usr/bin/cmd", Typeflag: tar.TypeReg},
+			},
+			expected: []string{
+				"usr",
+				"usr/bin",
+				"usr/bin/cmd",
+			},
+		},
+		{
+			name: "handle Alpine-style headers (with trailing slashes)",
+			headers: []tar.Header{
+				{Name: "usr/", Typeflag: tar.TypeDir},
+				{Name: "usr/bin/", Typeflag: tar.TypeDir},
+				{Name: "usr/bin/cmd", Typeflag: tar.TypeReg},
+			},
+			expected: []string{
+				"usr",
+				"usr/bin",
+				"usr/bin/cmd",
+			},
+		},
 	}
 
 	for _, tt := range cases {


### PR DESCRIPTION
### Context

We have an internal function `sortTarHeaders` that plays a critical role in the overall construction of a correct installed DB (`/lib/apk/db/installed` on resulting filesystems).

It turns out this function was dropping TAR headers (rather than sorting them) in the case when directory TAR entries had names like `usr/` instead of `usr`. This seems to be the case in APKs served by Alpine.

This led to us producing container images with incorrect installed DBs, specifically in that we were missing file entries altogether in some cases.

### What's changing

This PR fixes `sortTarHeaders` so that it continues to sort TAR headers correctly, even when encountering APKs from Alpine.

This PR also cleans up what appeared to be mistakes in the tests for `sortTarHeaders`, and adds additional test cases to assert "correctness" in the refactored implementation of `sortTarHeaders`; and, if nothing else, to document current expectations for the function in case we ever want to adjust our expectations of this function in a way that's more mindful of its current behavior.

I've also tested this change by using it within `apko` to produce an image and check its installed DB, using [this file](https://github.com/chainguard-images/images/blob/main/images/git/configs/latest.alpine.nonroot.apko.yaml) as the input configuration. Without this PR, there are `0` entries for regular files (starting with `R:`), and with this PR, there are now `453` entries for regular files.