### PR TITLE
Add UID/GID remapping in the tarball writer

### DIFF
--- a/pkg/signature/sign.go
+++ b/pkg/signature/sign.go
@@ -77,7 +77,7 @@ func SignIndex(ctx context.Context, logger logger.Logger, signingKey string, ind
 	logger.Printf("writing signed index to %s", indexFile)
 
 	var sigBuffer bytes.Buffer
-	if err := multitarctx.WriteTargz(ctx, &sigBuffer, sigFS); err != nil {
+	if err := multitarctx.WriteTargz(ctx, &sigBuffer, sigFS, sigFS); err != nil {
 		return fmt.Errorf("unable to write signature tarball: %w", err)
 	}
 

--- a/pkg/tarball/tarball.go
+++ b/pkg/tarball/tarball.go
@@ -28,6 +28,8 @@ type Context struct {
 	OverrideGname   string
 	SkipClose       bool
 	UseChecksums    bool
+	remapUIDs       map[int]int
+	remapGIDs       map[int]int
 	overridePerms   map[string]tar.Header
 }
 
@@ -80,6 +82,22 @@ func WithOverridePerms(files []tar.Header) Option {
 func WithOverrideUname(uname string) Option {
 	return func(ctx *Context) error {
 		ctx.OverrideUname = uname
+		return nil
+	}
+}
+
+// WithRemapUIDs sets a UID remapping in the Context.
+func WithRemapUIDs(uids map[int]int) Option {
+	return func(ctx *Context) error {
+		ctx.remapUIDs = uids
+		return nil
+	}
+}
+
+// WithRemapGIDs sets a GID remapping in the Context.
+func WithRemapGIDs(gids map[int]int) Option {
+	return func(ctx *Context) error {
+		ctx.remapGIDs = gids
 		return nil
 	}
 }


### PR DESCRIPTION
Required for chainguard-dev/melange/issues/501

This change adds support for remapping UIDs and GIDs when writing tarballs.
The API has changed, and a PR to melange has been drafted at https://github.com/chainguard-dev/melange/pull/784, with a PR to apko coming shortly.