### PR TITLE
Sort packages with bad versions correctly

### DIFF
--- a/pkg/apk/repo.go
+++ b/pkg/apk/repo.go
@@ -678,7 +678,8 @@ func (p *PkgResolver) sortPackages(pkgs []*repositoryPackage, compare *repositor
 		}
 		jVersion, err := p.parseVersion(jVersionStr)
 		if err != nil {
-			return false
+			// If j fails to parse, prefer i.
+			return true
 		}
 		versions := compareVersions(iVersion, jVersion)
 		if versions != equal {
@@ -692,7 +693,8 @@ func (p *PkgResolver) sortPackages(pkgs []*repositoryPackage, compare *repositor
 			}
 			jVersion, err := p.parseVersion(pkgs[j].Version)
 			if err != nil {
-				return false
+				// If j fails to parse, prefer i.
+				return true
 			}
 			versions := compareVersions(iVersion, jVersion)
 			if versions != equal {

--- a/pkg/apk/repo_test.go
+++ b/pkg/apk/repo_test.go
@@ -645,6 +645,7 @@ func TestSortPackages(t *testing.T) {
 		{"just versions", []repoPkgBase{
 			{&repository.Package{Name: "package1", Version: "1.0.0"}, "http://a.b.com", 2},
 			{&repository.Package{Name: "package1", Version: "2.0.1"}, "http://a.b.com", 0},
+			{&repository.Package{Name: "package1", Version: "1.2.0abc"}, "http://a.b.com", 3},
 			{&repository.Package{Name: "package1", Version: "1.2.0"}, "http://a.b.com", 1},
 		}, nil, nil},
 		{"just names", []repoPkgBase{


### PR DESCRIPTION
Previously, if sortPackage's less function encountered an error while parsing the version of a package, it would always return false. I can only assume this is a mistake that stems from returning a zero value when encountering an error, but in this case that orders packages improperly because we'd return false (asserting j > i) if either version i or j was invalid, which will not produce good output.

When sorting, we now consider versions that can be parsed as a closer match than versions that can't be parsed. So if version[i] can parse but version[j] can't parse, version[j] will come after version[i] when we sort them (all else being equal).