### PR TITLE
Optimize tarfs copying for large APKs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
 
       - uses: chainguard-dev/actions/goimports@main

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
 
       - name: golangci-lint

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chainguard-dev/go-apk
 
-go 1.20
+go 1.21
 
 require (
 	github.com/hashicorp/go-retryablehttp v0.7.4

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,7 @@ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=

--- a/pkg/apk/install.go
+++ b/pkg/apk/install.go
@@ -333,23 +333,23 @@ func (a *APK) lazilyInstallAPKFiles(ctx context.Context, wh writeHeaderer, tf *t
 	var files []tar.Header
 
 	var startedDataSection bool
-	for _, header := range tf.Entries() {
+	for _, file := range tf.Entries() {
 		// per https://git.alpinelinux.org/apk-tools/tree/src/extract_v2.c?id=337734941831dae9a6aa441e38611c43a5fd72c0#n120
 		//  * APKv1.0 compatibility - first non-hidden file is
 		//  * considered to start the data section of the file.
 		//  * This does not make any sense if the file has v2.0
 		//  * style .PKGINFO
-		if !startedDataSection && header.Name[0] == '.' && !strings.Contains(header.Name, "/") {
+		if !startedDataSection && file.Header.Name[0] == '.' && !strings.Contains(file.Header.Name, "/") {
 			continue
 		}
 		// whatever it is now, it is in the data section
 		startedDataSection = true
 
-		if err := wh.WriteHeader(header.Header, tf, pkg); err != nil {
+		if err := wh.WriteHeader(file.Header, tf, pkg); err != nil {
 			return nil, err
 		}
 
-		files = append(files, header.Header)
+		files = append(files, file.Header)
 	}
 
 	return files, nil


### PR DESCRIPTION
We were spending most of our time doing silly things like copying strings and copying Entry around. This memoizes path.Dir and also uses pointers for Entry (they're rather large) to avoid lots of copying.