### PR TITLE
Backfill missing meta fields in Package

### DIFF
--- a/pkg/apk/implementation.go
+++ b/pkg/apk/implementation.go
@@ -1004,6 +1004,10 @@ func packageInfo(exp *expandapk.APKExpanded) (*Package, error) {
 	if err = cfg.MapTo(pkg); err != nil {
 		return nil, fmt.Errorf("cfg.MapTo(): %w", err)
 	}
+	pkg.BuildTime = time.Unix(pkg.BuildDate, 0).UTC()
+	pkg.InstalledSize = pkg.Size
+	pkg.Size = uint64(exp.Size)
+	pkg.Checksum = exp.ControlHash
 
 	return pkg, nil
 }

--- a/pkg/apk/package.go
+++ b/pkg/apk/package.go
@@ -39,7 +39,9 @@ func PackageToInstalled(pkg *Package) (out []string) {
 	out = append(out, fmt.Sprintf("U:%s", pkg.URL))
 	out = append(out, fmt.Sprintf("D:%s", strings.Join(pkg.Dependencies, " ")))
 	out = append(out, fmt.Sprintf("p:%s", strings.Join(pkg.Provides, " ")))
-	out = append(out, fmt.Sprintf("r:%s", strings.Join(pkg.Replaces, " ")))
+	if len(pkg.Replaces) != 0 {
+		out = append(out, fmt.Sprintf("r:%s", strings.Join(pkg.Replaces, " ")))
+	}
 	out = append(out, fmt.Sprintf("c:%s", pkg.RepoCommit))
 	out = append(out, fmt.Sprintf("i:%s", pkg.InstallIf))
 	out = append(out, fmt.Sprintf("t:%d", pkg.BuildTime.Unix()))


### PR DESCRIPTION
My previous commit pulled a *Package out of .PKGINFO instead of APKINDEX, but I neglected to set some auxiliary fields that are used e.g. to set the build time.

Ideally, we could consolidate this into a single place, but I need to clean up our dependency graph hellscape first.