### PR TITLE
Allow existing packages to replace installed pkg

### DIFF
--- a/pkg/apk/implementation.go
+++ b/pkg/apk/implementation.go
@@ -1039,7 +1039,7 @@ func (a *APK) installPackage(ctx context.Context, pkg *Package, expanded *expand
 		}
 		defer packageData.Close()
 
-		installedFiles, err = a.installAPKFiles(ctx, packageData, pkg.Origin, pkg.Replaces)
+		installedFiles, err = a.installAPKFiles(ctx, packageData, pkg)
 		if err != nil {
 			return fmt.Errorf("unable to install files for pkg %s: %w", pkg.Name, err)
 		}

--- a/pkg/apk/installed.go
+++ b/pkg/apk/installed.go
@@ -282,6 +282,8 @@ func parseInstalled(installed io.Reader) ([]*InstalledPackage, error) { //nolint
 			pkg.Dependencies = strings.Split(val, " ")
 		case "p":
 			pkg.Provides = strings.Split(val, " ")
+		case "r":
+			pkg.Replaces = strings.Split(val, " ")
 		case "c":
 			pkg.RepoCommit = val
 		case "t":


### PR DESCRIPTION
This was done for our tarfs based things, but "normal" fs implementations still go through this path.