### PR TITLE
Fix triggers updates

### DIFF
--- a/pkg/apk/implementation.go
+++ b/pkg/apk/implementation.go
@@ -1046,7 +1046,7 @@ func (a *APK) installPackage(ctx context.Context, pkg *Package, expanded *expand
 	}
 
 	// update the scripts.tar
-	controlData, err := expanded.ControlData()
+	controlData, err := os.Open(expanded.ControlFile)
 	if err != nil {
 		return fmt.Errorf("opening control file %q: %w", expanded.ControlFile, err)
 	}


### PR DESCRIPTION
Using ControlData here was wrong because the existing code expects a gzipped tar.

Doing a very small targeted revert here, will follow up with a test and redo the change.