### PR TITLE
Add `ini` attribute to `provider_priority`

### DIFF
--- a/pkg/apk/package.go
+++ b/pkg/apk/package.go
@@ -72,7 +72,7 @@ type Package struct {
 	InstallIf        []string
 	Size             uint64 `ini:"size"`
 	InstalledSize    uint64
-	ProviderPriority uint64
+	ProviderPriority uint64 `ini:"provider_priority"`
 	BuildTime        time.Time
 	BuildDate        int64    `ini:"builddate"`
 	RepoCommit       string   `ini:"commit"`


### PR DESCRIPTION
This was fixed in the source of this forked logic here: https://gitlab.alpinelinux.org/alpine/go/-/commit/b0a7ab6b3bb60e75bb0f0146c2dcaa64c83e75d7