### PR TITLE
Bump golangci-lint version

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -17,4 +17,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
-          version: v1.52
+          version: v1.55

--- a/pkg/apk/cache.go
+++ b/pkg/apk/cache.go
@@ -236,7 +236,7 @@ func cacheDirFromFile(cacheFile string) string {
 
 func cacheFileFromEtag(cacheFile, etag string) string {
 	cacheDir := filepath.Dir(cacheFile)
-	ext := ".etag"
+	ext := ".etag" //nolint:goconst
 
 	// Keep all the index files under APKINDEX/ with appropriate file extension.
 	if strings.HasSuffix(cacheFile, "APKINDEX.tar.gz") {


### PR DESCRIPTION
I'm unsure that this solves anything, but we are seeing spurious errors in CI.