### PR TITLE
Fix sorting of post-suffix versions

### DIFF
--- a/pkg/apk/version.go
+++ b/pkg/apk/version.go
@@ -254,19 +254,14 @@ func compareVersions(actual, required packageVersion) versionCompare {
 	}
 	// same pre-suffix numbers
 	// compare post-suffixes
-	// because None is 0 but the lowest priority to make it easy to have a sane default,
-	// but lowest priority, we need some extra logic to handle
-	actualPostSuffix, requiredPostSuffix := actual.postSuffix, required.postSuffix
-	if actualPostSuffix == packageVersionPostModifierNone {
-		actualPostSuffix = packageVersionPostModifierMax
-	}
-	if requiredPostSuffix == packageVersionPostModifierNone {
-		requiredPostSuffix = packageVersionPostModifierMax
-	}
-	if actualPostSuffix > requiredPostSuffix {
+	//
+	// Note that whereas we do a None -> Max transformation for pre-suffixes, we intentionally
+	// leave post-suffixes alone, because they do not indicate a pre-release and should sort
+	// greater than a version lacking a post-suffix.
+	if actual.postSuffix > required.postSuffix {
 		return greater
 	}
-	if actualPostSuffix < requiredPostSuffix {
+	if actual.postSuffix < required.postSuffix {
 		return less
 	}
 	// same post-suffixes, compare post-suffix numbers

--- a/pkg/apk/version_test.go
+++ b/pkg/apk/version_test.go
@@ -832,6 +832,7 @@ func TestCompareVersion(t *testing.T) {
 		{"1.2.3-r0", equal, "1.2.3-r0"},
 		{"0.0_git20230331", less, "0.0_git20230508"},
 		{"2.0.0", less, "2.0.6-r0"},
+		{"6.4_p20231125-r0", greater, "6.4-r2"},
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("compare %s %s %s", tt.versionA, tt.expected, tt.versionB), func(t *testing.T) {


### PR DESCRIPTION
Previously we thought: 6.4-r2 > 6.4_p20231125-r0

This was backwards.