### PR TITLE
Rename and idiomaticize versioning structs

### DIFF
--- a/pkg/apk/repo.go
+++ b/pkg/apk/repo.go
@@ -485,7 +485,7 @@ func (p *PkgResolver) getPackageDependencies(pkg *RepositoryPackage, allowPin st
 				err1, err2                     error
 			)
 			actualVersion, err1 = p.parseVersion(pkg.Version)
-			if compare != versionNone {
+			if compare != versionAny {
 				requiredVersion, err2 = p.parseVersion(version)
 			}
 			// we accept invalid versions for ourself, but do not try to use it to fulfill

--- a/pkg/apk/version.go
+++ b/pkg/apk/version.go
@@ -363,23 +363,23 @@ func (v versionDependency) satisfies(actualVersion, requiredVersion packageVersi
 	}
 }
 
-type pinStuff struct {
+type parsedConstraint struct {
 	name    string
 	version string
 	dep     versionDependency
 	pin     string
 }
 
-func resolvePackageNameVersionPin(pkgName string) pinStuff {
+func resolvePackageNameVersionPin(pkgName string) parsedConstraint {
 	parts := packageNameRegex.FindAllStringSubmatch(pkgName, -1)
 	if len(parts) == 0 || len(parts[0]) < 2 {
-		return pinStuff{
+		return parsedConstraint{
 			name: pkgName,
 			dep:  versionAny,
 		}
 	}
 	// layout: [full match, name, =version, =|>|<, version, @pin, pin]
-	p := pinStuff{
+	p := parsedConstraint{
 		name:    parts[0][1],
 		version: parts[0][4],
 		pin:     parts[0][6],

--- a/pkg/apk/version.go
+++ b/pkg/apk/version.go
@@ -185,9 +185,9 @@ func parseVersion(version string) (packageVersion, error) {
 type versionCompare int
 
 const (
-	greater versionCompare = 0
-	equal   versionCompare = 1
-	less    versionCompare = 2
+	greater versionCompare = 1
+	equal   versionCompare = 0
+	less    versionCompare = -1
 )
 
 func (vc versionCompare) String() string {

--- a/pkg/apk/version.go
+++ b/pkg/apk/version.go
@@ -331,7 +331,7 @@ func includesVersion(actual, required packageVersion) bool {
 type versionDependency int
 
 const (
-	versionNone versionDependency = iota
+	versionAny versionDependency = iota
 	versionEqual
 	versionGreater
 	versionLess
@@ -346,7 +346,7 @@ func (v versionDependency) satisfies(actualVersion, requiredVersion packageVersi
 	}
 	c := compareVersions(actualVersion, requiredVersion)
 	switch v {
-	case versionNone:
+	case versionAny:
 		return true
 	case versionEqual:
 		return c == equal
@@ -375,7 +375,7 @@ func resolvePackageNameVersionPin(pkgName string) pinStuff {
 	if len(parts) == 0 || len(parts[0]) < 2 {
 		return pinStuff{
 			name: pkgName,
-			dep:  versionNone,
+			dep:  versionAny,
 		}
 	}
 	// layout: [full match, name, =version, =|>|<, version, @pin, pin]
@@ -383,7 +383,7 @@ func resolvePackageNameVersionPin(pkgName string) pinStuff {
 		name:    parts[0][1],
 		version: parts[0][4],
 		pin:     parts[0][6],
-		dep:     versionNone,
+		dep:     versionAny,
 	}
 
 	matcher := parts[0][3]
@@ -403,7 +403,7 @@ func resolvePackageNameVersionPin(pkgName string) pinStuff {
 		case "~":
 			p.dep = versionTilde
 		default:
-			p.dep = versionNone
+			p.dep = versionAny
 		}
 	}
 	return p
@@ -443,7 +443,7 @@ func withInstalledPackage(pkg *RepositoryPackage) filterOption {
 
 func (p *PkgResolver) filterPackages(pkgs []*repositoryPackage, opts ...filterOption) []*repositoryPackage {
 	o := &filterOptions{
-		compare: versionNone,
+		compare: versionAny,
 	}
 	for _, opt := range opts {
 		opt(o)
@@ -466,7 +466,7 @@ func (p *PkgResolver) filterPackages(pkgs []*repositoryPackage, opts ...filterOp
 		if (pkg.pinnedName != "" && pkg.pinnedName != o.allowPin && pkg.pinnedName != o.preferPin) && (o.installed == nil || installedURL != pkg.URL()) {
 			continue
 		}
-		if o.compare == versionNone {
+		if o.compare == versionAny {
 			passed = append(passed, pkg)
 			continue
 		}

--- a/pkg/apk/version_test.go
+++ b/pkg/apk/version_test.go
@@ -927,11 +927,11 @@ func TestResolverPackageNameVersionPin(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			stuff := resolvePackageNameVersionPin(tt.input)
-			require.Equal(t, tt.name, stuff.name)
-			require.Equal(t, tt.version, stuff.version)
-			require.Equal(t, tt.dep, stuff.dep)
-			require.Equal(t, tt.pin, stuff.pin)
+			constraint := resolvePackageNameVersionPin(tt.input)
+			require.Equal(t, tt.name, constraint.name)
+			require.Equal(t, tt.version, constraint.version)
+			require.Equal(t, tt.dep, constraint.dep)
+			require.Equal(t, tt.pin, constraint.pin)
 		})
 	}
 }

--- a/pkg/apk/version_test.go
+++ b/pkg/apk/version_test.go
@@ -877,9 +877,9 @@ func TestResolveVersion(t *testing.T) {
 		{"2.1.0", versionEqual, "", nil, "", "equal match but pinned"},
 		{"2.1.0", versionEqual, "", pinPackage.RepositoryPackage, "2.1.0", "equal match but pinned yet already installed"},
 		{"2.1.0", versionEqual, "pinA", nil, "2.1.0", "equal match and pin match"},
-		{"", versionNone, "", nil, "2.0.6-r0", "no requirement should get highest version"},
-		{"", versionNone, "", pinPackage.RepositoryPackage, pinPackage.Version, "no requirement should get highest version with pin, if installed"},
-		{"", versionNone, "", lowestPackage.RepositoryPackage, lowestPackage.Version, "no requirement should get installed priority"},
+		{"", versionAny, "", nil, "2.0.6-r0", "no requirement should get highest version"},
+		{"", versionAny, "", pinPackage.RepositoryPackage, pinPackage.Version, "no requirement should get highest version with pin, if installed"},
+		{"", versionAny, "", lowestPackage.RepositoryPackage, lowestPackage.Version, "no requirement should get installed priority"},
 		{"1.6", versionTilde, "", nil, "", "no match"},
 		{"1.7", versionTilde, "", nil, "1.7.1-r1", "fits within"},
 		{"1.7.1", versionTilde, "", nil, "1.7.1-r1", "fits within"},
@@ -913,15 +913,15 @@ func TestResolverPackageNameVersionPin(t *testing.T) {
 		dep     versionDependency
 		pin     string
 	}{
-		{"agetty", "agetty", "", versionNone, ""},
-		{"foo-dev", "foo-dev", "", versionNone, ""},
-		{"name@edge", "name", "", versionNone, "edge"},
+		{"agetty", "agetty", "", versionAny, ""},
+		{"foo-dev", "foo-dev", "", versionAny, ""},
+		{"name@edge", "name", "", versionAny, "edge"},
 		{"name=1.2.3", "name", "1.2.3", versionEqual, ""},
 		{"name>1.2.3", "name", "1.2.3", versionGreater, ""},
 		{"name<1.2.3", "name", "1.2.3", versionLess, ""},
 		{"name>=1.2.3", "name", "1.2.3", versionGreaterEqual, ""},
 		{"name<=1.2.3", "name", "1.2.3", versionLessEqual, ""},
-		{"name@edge=1.2.3", "name@edge=1.2.3", "", versionNone, ""}, // wrong order, so just returns the whole thing
+		{"name@edge=1.2.3", "name@edge=1.2.3", "", versionAny, ""}, // wrong order, so just returns the whole thing
 		{"name=1.2.3@community", "name", "1.2.3", versionEqual, "community"},
 	}
 


### PR DESCRIPTION
This is a non-functional change that just aligns some names with my current mental model of the code and uses the `cmp` convention for comparison functions. 