### PR TITLE
Generate actual APKs for install tests

### DIFF
--- a/pkg/apk/install.go
+++ b/pkg/apk/install.go
@@ -168,6 +168,7 @@ func (a *APK) installRegularFile(header *tar.Header, tr *tar.Reader,
 				if pk.Origin != pkg.Origin && !isReplaced {
 					continue
 				}
+
 				found = true
 				break
 			}

--- a/pkg/apk/installed.go
+++ b/pkg/apk/installed.go
@@ -323,10 +323,11 @@ func parseInstalled(installed io.Reader) ([]*InstalledPackage, error) { //nolint
 			}
 		case "F":
 			lastDir = &tar.Header{
-				Name: val,
-				Mode: 0o755,
-				Uid:  0,
-				Gid:  0,
+				Name:     val,
+				Mode:     0o755,
+				Uid:      0,
+				Gid:      0,
+				Typeflag: tar.TypeDir,
 			}
 			pkg.Files = append(pkg.Files, lastDir)
 			lastFile = nil

--- a/pkg/apk/package.go
+++ b/pkg/apk/package.go
@@ -84,6 +84,7 @@ type Package struct {
 	BuildDate        int64    `ini:"builddate"`
 	RepoCommit       string   `ini:"commit"`
 	Replaces         []string `ini:"replaces,,allowshadow"`
+	DataHash         string   `ini:"datahash"`
 }
 
 func (p *Package) String() string {
@@ -96,7 +97,7 @@ func (p *Package) Filename() string {
 	return fmt.Sprintf("%s-%s.apk", p.Name, p.Version)
 }
 
-// ChecksumString returns a human-readable version of the checksum.
+// ChecksumString returns a human-readable version of the control section checksum.
 func (p *Package) ChecksumString() string {
 	return "Q1" + base64.StdEncoding.EncodeToString(p.Checksum)
 }

--- a/pkg/apk/package_test.go
+++ b/pkg/apk/package_test.go
@@ -22,7 +22,7 @@ func TestParsePackage(t *testing.T) {
 			Description: "the GNU hello world program",
 			License:     "GPL-3.0-or-later",
 			Origin:      "hello-wolfi",
-			// This is 3a6c21f20a07bebf261162b5ab13cb041d7c1cc3e1edc644aaa99f109f87d887
+			// This is sha1 of control section.
 			Checksum:      []byte{0x8f, 0xd8, 0x6e, 0x0a, 0x6c, 0x6a, 0x58, 0xa0, 0xd1, 0xf9, 0xa6, 0xca, 0xb2, 0x47, 0x18, 0xf1, 0xef, 0xda, 0x64, 0xca},
 			Dependencies:  []string{"so:ld-linux-x86-64.so.2", "so:libc.so.6"},
 			Provides:      []string{"cmd:hello=2.12.1-r0"},
@@ -30,6 +30,7 @@ func TestParsePackage(t *testing.T) {
 			InstalledSize: 640091,
 			BuildTime:     time.Date(1970, 5, 23, 21, 21, 18, 0, time.UTC),
 			BuildDate:     12345678,
+			DataHash:      "3a6c21f20a07bebf261162b5ab13cb041d7c1cc3e1edc644aaa99f109f87d887",
 		},
 	}, {
 		apk: "hello-0.1.0-r0.apk",
@@ -39,13 +40,14 @@ func TestParsePackage(t *testing.T) {
 			Arch:        "x86_64",
 			Description: "just a test package",
 			License:     "Apache-2.0",
-			// This is 1c6e256b3f9e0629730659382a81f82d4ac81b0f04fc9e70a6b1b5c653989911
+			// This is sha1 of control section.
 			Checksum:      []byte{0x0c, 0xd5, 0x99, 0x79, 0x69, 0x2f, 0x88, 0xde, 0xcc, 0x25, 0xe7, 0x4b, 0xa5, 0x83, 0x3c, 0xc8, 0x1b, 0xe6, 0x9c, 0x63},
 			Dependencies:  []string{"busybox"},
 			Size:          499,
 			InstalledSize: 4117,
 			BuildTime:     time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
 			BuildDate:     0,
+			DataHash:      "1c6e256b3f9e0629730659382a81f82d4ac81b0f04fc9e70a6b1b5c653989911",
 		},
 	}, {
 		apk: "replaces/replaces-0.0.1-r0.apk",
@@ -61,6 +63,7 @@ func TestParsePackage(t *testing.T) {
 			InstalledSize: 2532,
 			BuildTime:     time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
 			BuildDate:     0,
+			DataHash:      "71b14cc95cf71f4f6c1666cb1699b3bc4f52d17f5575c893324c8f62bb19d9b3",
 		},
 	}} {
 		t.Run(c.apk, func(t *testing.T) {


### PR DESCRIPTION
This uses the public InstallPackages method, so it won't bypass a lot of useful logic. Currently, a lot of the unit tests would fail if we checked for duplicate files in the installed DB. I've commented that check out for now in there so I can make the fix separately.

Part of https://github.com/chainguard-dev/go-apk/issues/178