### PR TITLE
Deduplicate idb entries

### DIFF
--- a/pkg/apk/install_test.go
+++ b/pkg/apk/install_test.go
@@ -207,8 +207,7 @@ func TestInstallAPKFiles(t *testing.T) {
 			require.NoError(t, err, "error reading %s", overwriteFilename)
 			require.Equal(t, finalContent, actual)
 
-			// TODO: Uncomment this when we fix it.
-			// checkDuplicateIDBEntries(t, apk)
+			checkDuplicateIDBEntries(t, apk)
 		})
 		t.Run("same origin", func(t *testing.T) {
 			apk, src, err := testGetTestAPK()
@@ -237,8 +236,7 @@ func TestInstallAPKFiles(t *testing.T) {
 			require.NoError(t, err, "error reading %s", overwriteFilename)
 			require.Equal(t, finalContent, actual)
 
-			// TODO: Uncomment this when we fix it.
-			// checkDuplicateIDBEntries(t, apk)
+			checkDuplicateIDBEntries(t, apk)
 		})
 		t.Run("different origin with same content", func(t *testing.T) {
 			apk, src, err := testGetTestAPK()
@@ -266,8 +264,7 @@ func TestInstallAPKFiles(t *testing.T) {
 			require.NoError(t, err, "error reading %s", overwriteFilename)
 			require.Equal(t, originalContent, actual)
 
-			// TODO: Uncomment this when we fix it.
-			// checkDuplicateIDBEntries(t, apk)
+			checkDuplicateIDBEntries(t, apk)
 		})
 		t.Run("different origin and content, but is replaced", func(t *testing.T) {
 			apk, src, err := testGetTestAPK()
@@ -296,8 +293,7 @@ func TestInstallAPKFiles(t *testing.T) {
 			require.NoError(t, err, "error reading %s", overwriteFilename)
 			require.Equal(t, originalContent, actual)
 
-			// TODO: Uncomment this when we fix it.
-			// checkDuplicateIDBEntries(t, apk)
+			checkDuplicateIDBEntries(t, apk)
 		})
 	})
 }

--- a/pkg/apk/installed.go
+++ b/pkg/apk/installed.go
@@ -65,6 +65,7 @@ func (a *APK) addInstalledPackage(pkg *Package, files []tar.Header) error {
 		perm := f.Mode & 0777
 		user := f.Uid
 		group := f.Gid
+
 		if f.Typeflag == tar.TypeDir {
 			dirName := strings.TrimSuffix(f.Name, fmt.Sprintf("%c", filepath.Separator))
 			pkgLines = append(pkgLines, fmt.Sprintf("F:%s", dirName))


### PR DESCRIPTION
To do this, we track each file's "owner" when installing packages so that we only include a (regular) file under the package which wrote it, where the last write wins.

This handles files being overwritten by same-origin packages and also files being overwritten via "replaces" directives.

Fixes https://github.com/chainguard-dev/go-apk/issues/178