### PR TITLE
Avoid redundant work in solver

### DIFF
--- a/pkg/apk/repo_test.go
+++ b/pkg/apk/repo_test.go
@@ -504,7 +504,7 @@ func TestGetPackageDependencies(t *testing.T) {
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				deps, _, err := resolver.getPackageDependencies(pkg6[0], "", tt.allow, nil, nil)
+				deps, _, err := resolver.getPackageDependencies(pkg6[0], "", tt.allow, nil, nil, nil)
 				require.NoErrorf(t, err, "unable to get dependencies")
 
 				actual := make([]string, 0, len(deps))
@@ -686,9 +686,10 @@ func TestSortPackages(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var (
-				pkgs     []*RepositoryPackage
-				pkg      *RepositoryPackage
-				existing = map[string]*RepositoryPackage{}
+				pkgs            []*RepositoryPackage
+				pkg             *RepositoryPackage
+				existing        = map[string]*RepositoryPackage{}
+				existingOrigins = map[string]bool{}
 			)
 			for _, pkg := range tt.pkgs {
 				// we cheat and use the InstalledSize for the preferred order, so that it gets carried around.
@@ -702,10 +703,11 @@ func TestSortPackages(t *testing.T) {
 			}
 			for _, pkg := range tt.existing {
 				existing[pkg.pkg.Name] = NewRepositoryPackage(pkg.pkg, &RepositoryWithIndex{Repository: &Repository{URI: pkg.repo}})
+				existingOrigins[pkg.pkg.Origin] = true
 			}
 			namedPkgs := testNamedPackageFromPackages(pkgs)
 			pr := NewPkgResolver(context.Background(), []NamedIndex{})
-			pr.sortPackages(namedPkgs, pkg, "", existing, "")
+			pr.sortPackages(namedPkgs, pkg, "", existing, existingOrigins, "")
 			for i, pkg := range namedPkgs {
 				require.Equal(t, int(pkg.InstalledSize), i, "position matches")
 			}

--- a/pkg/apk/version_test.go
+++ b/pkg/apk/version_test.go
@@ -891,15 +891,17 @@ func TestResolveVersion(t *testing.T) {
 			found := pr.filterPackages(pkgs, withVersion(tt.version, tt.compare), withPreferPin(tt.pin), withInstalledPackage(tt.installed))
 			// add the existing in, if any
 			existing := make(map[string]*RepositoryPackage)
+			existingOrigins := make(map[string]bool)
 			if tt.installed != nil {
 				existing[tt.installed.Name] = tt.installed
+				existingOrigins[tt.installed.Origin] = true
 			}
-			pr.sortPackages(found, nil, "", existing, tt.pin)
+			pkg := pr.bestPackage(found, nil, "", existing, existingOrigins, tt.pin)
 			if tt.want == "" {
-				require.Nil(t, found, "version resolver should not find a package")
+				require.Nil(t, pkg, "version resolver should not find a package")
 			} else {
-				require.NotNil(t, found, "version resolver should find a package")
-				require.Equal(t, found[0].Version, tt.want, "version resolver gets correct version")
+				require.NotNil(t, pkg, "version resolver should find a package")
+				require.Equal(t, pkg.Version, tt.want, "version resolver gets correct version")
 			}
 		})
 	}


### PR DESCRIPTION
This implements two optimizations in the solver.

There are a couple places where we call sortPackages and take the 0th item, then ignore the rest of the results. This is wasteful, since sorting the entire slice takes log(n) times longer than finding the minimum element in the slice. Where we used to do that, we now call bestPackage() instead.

We were also spending a lot of time allocating maps that contained origins that we have already seen. I've hoisted that code up to the point where it makes most sense so that we can share that result across multiple calls to bestPackage/sortPackages.