### PR TITLE
Always set Package.BuildDate

### DIFF
--- a/pkg/apk/apkindex.go
+++ b/pkg/apk/apkindex.go
@@ -137,6 +137,7 @@ func ParsePackageIndex(apkIndexUnpacked io.Reader) ([]*Package, error) {
 			if err != nil {
 				return nil, fmt.Errorf("cannot parse build time %s: %w", val, err)
 			}
+			pkg.BuildDate = i
 			pkg.BuildTime = time.Unix(i, 0).UTC()
 		case "i":
 			pkg.InstallIf = strings.Split(val, " ")

--- a/pkg/apk/installed.go
+++ b/pkg/apk/installed.go
@@ -292,6 +292,7 @@ func parseInstalled(installed io.Reader) ([]*InstalledPackage, error) { //nolint
 			if err != nil {
 				return nil, fmt.Errorf("cannot parse build time %s: %w", val, err)
 			}
+			pkg.BuildDate = i
 			pkg.BuildTime = time.Unix(i, 0).UTC()
 		case "i":
 			pkg.InstallIf = strings.Split(val, " ")


### PR DESCRIPTION
Were were just directly setting BuildTime which is confusing.