### PR TITLE
Initial refactorings for expanding base image support in apko

### DIFF
--- a/pkg/apk/apkindex.go
+++ b/pkg/apk/apkindex.go
@@ -127,9 +127,13 @@ func ParsePackageIndex(apkIndexUnpacked io.Reader) ([]*Package, error) {
 		case "U":
 			pkg.URL = val
 		case "D":
-			pkg.Dependencies = strings.Split(val, " ")
+			if val != "" {
+				pkg.Dependencies = strings.Split(val, " ")
+			}
 		case "p":
-			pkg.Provides = strings.Split(val, " ")
+			if val != "" {
+				pkg.Provides = strings.Split(val, " ")
+			}
 		case "c":
 			pkg.RepoCommit = val
 		case "t":

--- a/pkg/apk/apkindex.go
+++ b/pkg/apk/apkindex.go
@@ -79,6 +79,15 @@ type APKIndex struct { //nolint:revive
 	Packages    []*Package
 }
 
+// Splitting empty string results in single element array with one empty string, which would
+// be treated as package with empty name.
+func splitRepeatedField(val string) []string {
+	if val == "" {
+		return nil
+	}
+	return strings.Split(val, " ")
+}
+
 // ParsePackageIndex parses a plain (uncompressed) APKINDEX file. It returns an
 // ApkIndex struct
 func ParsePackageIndex(apkIndexUnpacked io.Reader) ([]*Package, error) {
@@ -127,17 +136,9 @@ func ParsePackageIndex(apkIndexUnpacked io.Reader) ([]*Package, error) {
 		case "U":
 			pkg.URL = val
 		case "D":
-			// Splitting empty string results in single element array with one empty string, which would
-			// be treated as package with empty name.
-			if val != "" {
-				pkg.Dependencies = strings.Split(val, " ")
-			}
+			pkg.Dependencies = splitRepeatedField(val)
 		case "p":
-			// Splitting empty string results in single element array with one empty string, which would
-			// be treated as package with empty name.
-			if val != "" {
-				pkg.Provides = strings.Split(val, " ")
-			}
+			pkg.Provides = splitRepeatedField(val)
 		case "c":
 			pkg.RepoCommit = val
 		case "t":

--- a/pkg/apk/apkindex.go
+++ b/pkg/apk/apkindex.go
@@ -149,7 +149,7 @@ func ParsePackageIndex(apkIndexUnpacked io.Reader) ([]*Package, error) {
 			pkg.BuildDate = i
 			pkg.BuildTime = time.Unix(i, 0).UTC()
 		case "i":
-			pkg.InstallIf = strings.Split(val, " ")
+			pkg.InstallIf = splitRepeatedField(val)
 		case "S":
 			size, err := strconv.ParseUint(val, 10, 64)
 			if err != nil {

--- a/pkg/apk/apkindex.go
+++ b/pkg/apk/apkindex.go
@@ -127,10 +127,14 @@ func ParsePackageIndex(apkIndexUnpacked io.Reader) ([]*Package, error) {
 		case "U":
 			pkg.URL = val
 		case "D":
+			// Splitting empty string results in single element array with one empty string, which would
+			// be treated as package with empty name.
 			if val != "" {
 				pkg.Dependencies = strings.Split(val, " ")
 			}
 		case "p":
+			// Splitting empty string results in single element array with one empty string, which would
+			// be treated as package with empty name.
 			if val != "" {
 				pkg.Provides = strings.Split(val, " ")
 			}

--- a/pkg/apk/apkindex_test.go
+++ b/pkg/apk/apkindex_test.go
@@ -210,3 +210,36 @@ func TestArchiveFromIndex(t *testing.T) {
 	require.Truef(t, foundApkIndex, "Could not locate file %s in archive", apkIndexFilename)
 	require.Truef(t, foundDescription, "Could not locate file %s in archive", descriptionFilename)
 }
+
+func TestEmptyRepeatedFields(t *testing.T) {
+	apkIndexFile := strings.NewReader(heredoc.Doc(`
+		C:Q1Deb0jNytkrjPW4N/eKLZ43BwOlw=
+		P:a-pkg
+		V:1.2.3-r1
+		A:x86_64
+		S:9180
+		I:40960
+		T:A sample package
+		U:http://a.package.org
+		L:Apache-2.0
+		o:a-pkg
+		m:maintainer <maint@iner.org>
+		t:1600096848
+		c:af13bd168c9d86ede4ad1be5c4ceac79253a7e26
+		D:
+		p:
+		i:abc xyz
+		k:9001
+		
+	`))
+
+	packages, err := ParsePackageIndex(io.NopCloser(apkIndexFile))
+	require.NoError(t, err)
+
+	require.Len(t, packages, 1, "Expected exactly 1 package")
+
+	pkg := packages[0]
+
+	require.Len(t, pkg.Provides, 0, "Expected no provides")
+	require.Len(t, pkg.Dependencies, 0, "Expected no dependancies")
+}

--- a/pkg/apk/apkindex_test.go
+++ b/pkg/apk/apkindex_test.go
@@ -241,5 +241,5 @@ func TestEmptyRepeatedFields(t *testing.T) {
 	pkg := packages[0]
 
 	require.Len(t, pkg.Provides, 0, "Expected no provides")
-	require.Len(t, pkg.Dependencies, 0, "Expected no dependancies")
+	require.Len(t, pkg.Dependencies, 0, "Expected no dependencies")
 }

--- a/pkg/apk/implementation.go
+++ b/pkg/apk/implementation.go
@@ -684,7 +684,7 @@ func (a *APK) InstallPackages(ctx context.Context, sourceDateEpoch *time.Time, a
 			return owner != pkg
 		})
 
-		if err := a.addInstalledPackage(pkg, files); err != nil {
+		if err := a.AddInstalledPackage(pkg, files); err != nil {
 			return fmt.Errorf("unable to update installed file for pkg %s: %w", pkg.Name, err)
 		}
 	}

--- a/pkg/apk/implementation.go
+++ b/pkg/apk/implementation.go
@@ -57,14 +57,15 @@ import (
 var globalApkCache = &apkCache{}
 
 type APK struct {
-	arch              string
-	version           string
-	fs                apkfs.FullFS
-	executor          Executor
-	ignoreMknodErrors bool
-	client            *http.Client
-	cache             *cache
-	ignoreSignatures  bool
+	arch               string
+	version            string
+	fs                 apkfs.FullFS
+	executor           Executor
+	ignoreMknodErrors  bool
+	client             *http.Client
+	cache              *cache
+	ignoreSignatures   bool
+	noSignatureIndexes []string
 
 	// filename to owning package, last write wins
 	installedFiles map[string]*Package
@@ -81,14 +82,15 @@ func New(options ...Option) (*APK, error) {
 	rhttp.Logger = hclog.Default()
 
 	return &APK{
-		client:            rhttp.StandardClient(),
-		fs:                opt.fs,
-		arch:              opt.arch,
-		executor:          opt.executor,
-		ignoreMknodErrors: opt.ignoreMknodErrors,
-		version:           opt.version,
-		cache:             opt.cache,
-		installedFiles:    map[string]*Package{},
+		client:             rhttp.StandardClient(),
+		fs:                 opt.fs,
+		arch:               opt.arch,
+		executor:           opt.executor,
+		ignoreMknodErrors:  opt.ignoreMknodErrors,
+		version:            opt.version,
+		cache:              opt.cache,
+		noSignatureIndexes: opt.noSignatureIndexes,
+		installedFiles:     map[string]*Package{},
 	}, nil
 }
 

--- a/pkg/apk/implementation_test.go
+++ b/pkg/apk/implementation_test.go
@@ -115,6 +115,29 @@ func TestSetWorld(t *testing.T) {
 	require.Equal(t, expected, string(actual), "unexpected content for etc/apk/world:\nexpected %s\nactual %s", expected, actual)
 }
 
+func TestSetWorldWithVersions(t *testing.T) {
+	ctx := context.Background()
+	src := apkfs.NewMemFS()
+	apk, err := New(WithFS(src), WithIgnoreMknodErrors(ignoreMknodErrors))
+	require.NoError(t, err)
+	// for initialization
+	err = src.MkdirAll("etc/apk", 0o755)
+	require.NoError(t, err)
+
+	// set these packages in a random order; it should write them to world in the correct order
+	packages := []string{"foo=1.0.0", "bar=1.2.3", "abc", "zulu", "foo"}
+	err = apk.SetWorld(ctx, packages)
+	require.NoError(t, err)
+
+	// check all of the contents
+	actual, err := src.ReadFile("etc/apk/world")
+	require.NoError(t, err)
+
+	sort.Strings(packages)
+	expected := strings.Join(packages, "\n") + "\n"
+	require.Equal(t, expected, string(actual), "unexpected content for etc/apk/world:\nexpected %s\nactual %s", expected, actual)
+}
+
 func TestSetRepositories(t *testing.T) {
 	ctx := context.Background()
 	src := apkfs.NewMemFS()

--- a/pkg/apk/implementation_test.go
+++ b/pkg/apk/implementation_test.go
@@ -157,7 +157,7 @@ func TestSetRepositories(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := strings.Join(repos, "\n") + "\n"
-	require.Equal(t, expected, string(actual), "unexpected content for etc/apk/repositories:\nexpected %s\nactual %s", expected, actual)
+	require.Equal(t, expected, string(actual))
 }
 
 func TestSetRepositories_Empty(t *testing.T) {

--- a/pkg/apk/index.go
+++ b/pkg/apk/index.go
@@ -233,7 +233,9 @@ func getRepositoryIndex(ctx context.Context, u string, keys map[string][]byte, a
 	}
 
 	// validate the signature
-	if !opts.ignoreSignatures {
+	// TODO - ignore signature for base image APKINDEX
+	// Was: !opts.ignoreSignatures
+	if false {
 		buf := bytes.NewReader(b)
 		gzipReader, err := gzip.NewReader(buf)
 		if err != nil {

--- a/pkg/apk/installed.go
+++ b/pkg/apk/installed.go
@@ -34,7 +34,7 @@ import (
 
 type InstalledPackage struct {
 	Package
-	Files []*tar.Header
+	Files []tar.Header
 }
 
 // getInstalledPackages get list of installed packages
@@ -48,7 +48,7 @@ func (a *APK) GetInstalled() ([]*InstalledPackage, error) {
 }
 
 // addInstalledPackage add a package to the list of installed packages
-func (a *APK) addInstalledPackage(pkg *Package, files []tar.Header) error {
+func (a *APK) AddInstalledPackage(pkg *Package, files []tar.Header) error {
 	// be sure to open the file in append mode so we add to the end
 	installedFile, err := a.fs.OpenFile(installedFilePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
 	if err != nil {
@@ -331,7 +331,7 @@ func ParseInstalled(installed io.Reader) ([]*InstalledPackage, error) { //nolint
 				Gid:      0,
 				Typeflag: tar.TypeDir,
 			}
-			pkg.Files = append(pkg.Files, lastDir)
+			pkg.Files = append(pkg.Files, *lastDir)
 			lastFile = nil
 		case "M":
 			// directory perms if not 0o755
@@ -356,7 +356,7 @@ func ParseInstalled(installed io.Reader) ([]*InstalledPackage, error) { //nolint
 				Uid:  0,
 				Gid:  0,
 			}
-			pkg.Files = append(pkg.Files, lastFile)
+			pkg.Files = append(pkg.Files, *lastFile)
 		case "a":
 			// file perms if not 0o644
 			if lastFile == nil {

--- a/pkg/apk/installed.go
+++ b/pkg/apk/installed.go
@@ -44,7 +44,7 @@ func (a *APK) GetInstalled() ([]*InstalledPackage, error) {
 		return nil, fmt.Errorf("could not open installed file in %s at %s: %w", a.fs, installedFilePath, err)
 	}
 	defer installedFile.Close()
-	return parseInstalled(installedFile)
+	return ParseInstalled(installedFile)
 }
 
 // addInstalledPackage add a package to the list of installed packages
@@ -230,7 +230,7 @@ func (a *APK) readTriggers() (io.ReadCloser, error) {
 }
 
 // parseInstalled parses an installed file. It returns the installed packages.
-func parseInstalled(installed io.Reader) ([]*InstalledPackage, error) { //nolint:gocyclo
+func ParseInstalled(installed io.Reader) ([]*InstalledPackage, error) { //nolint:gocyclo
 	if closer, ok := installed.(io.Closer); ok {
 		defer closer.Close()
 	}

--- a/pkg/apk/installed_test.go
+++ b/pkg/apk/installed_test.go
@@ -84,8 +84,8 @@ func TestAddInstalledPackage(t *testing.T) {
 			paxRecordsChecksumKey: "91abf197227d2fe71d016f4ccb68b16c9c9b2768",
 		}}, // should generate extra a: perms line
 	}
-	// addInstalledPackage(pkg *Package, files []tar.Header) error
-	err = a.addInstalledPackage(newPkg, newFiles)
+	// AddInstalledPackage(pkg *Package, files []tar.Header) error
+	err = a.AddInstalledPackage(newPkg, newFiles)
 	require.NoErrorf(t, err, "unable to add installed package: %v", err)
 	// check that the new packages were added
 	pkgs, err := a.GetInstalled()

--- a/pkg/apk/options.go
+++ b/pkg/apk/options.go
@@ -23,12 +23,13 @@ import (
 )
 
 type opts struct {
-	executor          Executor
-	arch              string
-	ignoreMknodErrors bool
-	fs                apkfs.FullFS
-	version           string
-	cache             *cache
+	executor           Executor
+	arch               string
+	ignoreMknodErrors  bool
+	fs                 apkfs.FullFS
+	version            string
+	cache              *cache
+	noSignatureIndexes []string
 }
 
 type Option func(*opts) error
@@ -93,6 +94,13 @@ func WithCache(cacheDir string, offline bool) Option {
 			dir:     cacheDir,
 			offline: offline,
 		}
+		return nil
+	}
+}
+
+func WithNoSignatureIndexes(noSignatureIndex ...string) Option {
+	return func(o *opts) error {
+		o.noSignatureIndexes = append(o.noSignatureIndexes, noSignatureIndex...)
 		return nil
 	}
 }

--- a/pkg/apk/repo.go
+++ b/pkg/apk/repo.go
@@ -180,7 +180,7 @@ func (a *APK) GetRepositoryIndexes(ctx context.Context, ignoreSignatures bool) (
 	if a.cache != nil {
 		httpClient = a.cache.client(httpClient, true)
 	}
-	return GetRepositoryIndexes(ctx, repos, keys, arch, WithIgnoreSignatures(ignoreSignatures), WithHTTPClient(httpClient))
+	return GetRepositoryIndexes(ctx, repos, keys, arch, WithIgnoreSignatures(ignoreSignatures), WithHTTPClient(httpClient), WithIgnoreSignatureForIndexes(a.noSignatureIndexes...))
 }
 
 // PkgResolver resolves packages from a list of indexes.

--- a/pkg/apk/repo.go
+++ b/pkg/apk/repo.go
@@ -308,6 +308,7 @@ func (p *PkgResolver) disqualifyProviders(constraint string, dq map[*RepositoryP
 // Disqualify anything that conflicts with the given pkg.
 func (p *PkgResolver) disqualifyConflicts(pkg *RepositoryPackage, dq map[*RepositoryPackage]string) {
 	for _, prov := range pkg.Provides {
+		fmt.Println("HELLO PROVIDE ", prov, " PKG ", pkg.Name)
 		name := p.resolvePackageNameVersionPin(prov).name
 		providers, ok := p.nameMap[name]
 		if !ok {

--- a/pkg/apk/repo.go
+++ b/pkg/apk/repo.go
@@ -308,7 +308,6 @@ func (p *PkgResolver) disqualifyProviders(constraint string, dq map[*RepositoryP
 // Disqualify anything that conflicts with the given pkg.
 func (p *PkgResolver) disqualifyConflicts(pkg *RepositoryPackage, dq map[*RepositoryPackage]string) {
 	for _, prov := range pkg.Provides {
-		fmt.Println("HELLO PROVIDE ", prov, " PKG ", pkg.Name)
 		name := p.resolvePackageNameVersionPin(prov).name
 		providers, ok := p.nameMap[name]
 		if !ok {


### PR DESCRIPTION
This is a preparation to allow apko building on top of base image (https://github.com/chainguard-dev/apko/issues/806)

1. Allow ignoring signature for specific apk index - the one from the base image is not signed. We could sign it artificially, but perhaps explicitly ignoring is ok.
2. Add some tests for resolution to make sure some convoluted cases.
3. Fix apk index parsing - apko saves the apkindex file in a way that even if there are no provides / depends it still puts the empty value for p: and D: tokens. `"".split(" ")` results in one element array `[""]`.
4. Split ResolveAndCalculateWorld into Resolve and Calculate so that apko can later add some logic in between. This is important, because Resolve operates on apk indexes only, while calculate fetches packages - this will not be possible for packages from base image, as some of them might be private.
5. Changed the `InstalledPackage` struct to have  `[]tar.Header` instead of `[]*tar.Header`. This makes it consistent with `AddInstalledPackage` arguments. Not strictly needed, can do conversions wherever needed instead.