### PR TITLE
Optimize tarfs

### DIFF
--- a/internal/tarfs/tarfs.go
+++ b/internal/tarfs/tarfs.go
@@ -17,19 +17,15 @@ package tarfs
 import (
 	"archive/tar"
 	"bufio"
+	"cmp"
 	"errors"
 	"fmt"
 	"io"
 	"io/fs"
 	"path"
-	"strings"
-	"testing/iotest"
+	"slices"
 	"time"
-
-	"golang.org/x/exp/slices"
 )
-
-var emptyReader = iotest.ErrReader(io.EOF)
 
 type Entry struct {
 	Header tar.Header
@@ -60,10 +56,9 @@ func (e Entry) IsDir() bool {
 }
 
 type File struct {
-	fsys   *FS
-	handle io.ReadSeekCloser
-	r      io.Reader
-	Entry  *Entry
+	fsys  *FS
+	sr    *io.SectionReader
+	Entry *Entry
 }
 
 func (f *File) Stat() (fs.FileInfo, error) {
@@ -71,75 +66,26 @@ func (f *File) Stat() (fs.FileInfo, error) {
 }
 
 func (f *File) Read(p []byte) (int, error) {
-	return f.r.Read(p)
-}
-
-func (f *File) relativeOffset(offset int64, whence int) (int64, error) {
-	switch whence {
-	case io.SeekCurrent:
-		return offset, nil
-	case io.SeekStart:
-		if offset > f.Entry.Header.Size {
-			return 0, fmt.Errorf("offset %d greater than file size %d", offset, f.Entry.Header.Size)
-		}
-	case io.SeekEnd:
-		if offset+f.Entry.Header.Size < 0 {
-			return 0, fmt.Errorf("offset %d greater than file size %d", offset, f.Entry.Header.Size)
-		}
-	default:
-		return 0, fmt.Errorf("invalid whence: %d", whence)
-	}
-
-	return f.Entry.Offset + offset, nil
+	return f.sr.Read(p)
 }
 
 func (f *File) Seek(offset int64, whence int) (int64, error) {
-	newOffset, err := f.relativeOffset(offset, whence)
-	if err != nil {
-		return 0, err
-	}
-
-	n, err := f.handle.Seek(newOffset, whence)
-	if err != nil {
-		return 0, err
-	}
-
-	return n - f.Entry.Offset, nil
+	return f.sr.Seek(offset, whence)
 }
 
 func (f *File) ReadAt(p []byte, off int64) (int, error) {
-	// If the underlying ReadSeekCloser implements ReaderAt, just use that.
-	if ra, ok := f.handle.(io.ReaderAt); ok {
-		bytesLeft := f.Entry.Header.Size - off
-		if int64(len(p)) > bytesLeft {
-			p = p[:bytesLeft]
-		}
-		return ra.ReadAt(p, f.Entry.Offset+off)
-	}
-
-	if f.handle != nil {
-		// Otherwise do a Seek and ReadFull.
-		if _, err := f.handle.Seek(f.Entry.Offset+off, io.SeekStart); err != nil {
-			return 0, err
-		}
-		f.r = io.LimitReader(f.handle, f.Entry.Header.Size-off)
-	}
-
-	return io.ReadFull(f.r, p)
+	return f.sr.ReadAt(p, off)
 }
 
 func (f *File) Close() error {
-	if f.handle == nil {
-		return nil
-	}
-
-	return f.handle.Close()
+	return nil
 }
 
 type FS struct {
-	open  func() (io.ReadSeekCloser, error)
+	ra    io.ReaderAt
 	files []*Entry
 	index map[string]int
+	dirs  map[string][]fs.DirEntry
 }
 
 func (fsys *FS) Readlink(name string) (string, error) {
@@ -172,37 +118,13 @@ func (fsys *FS) Open(name string) (fs.File, error) {
 		Entry: e,
 	}
 
-	if e.Header.Size == 0 {
-		f.r = emptyReader
-		return f, nil
-	}
-
-	rc, err := fsys.OpenAt(e.Offset)
-	if err != nil {
-		return nil, err
-	}
-	f.handle = rc
-	f.r = io.LimitReader(rc, e.Header.Size)
+	f.sr = io.NewSectionReader(fsys.ra, e.Offset, e.Header.Size)
 
 	return f, nil
 }
 
 func (fsys *FS) Entries() []*Entry {
 	return fsys.files
-}
-
-func (fsys *FS) OpenAt(offset int64) (io.ReadSeekCloser, error) {
-	// TODO: We can use ReadAt to avoid opening the file multiple times.
-	f, err := fsys.open()
-	if err != nil {
-		return nil, err
-	}
-
-	if _, err := f.Seek(offset, io.SeekStart); err != nil {
-		return nil, err
-	}
-
-	return f, nil
 }
 
 type root struct{}
@@ -229,23 +151,12 @@ func (fsys *FS) Stat(name string) (fs.FileInfo, error) {
 }
 
 func (fsys *FS) ReadDir(name string) ([]fs.DirEntry, error) {
-	children := []fs.DirEntry{}
-	for _, f := range fsys.files {
-		// This is load bearing.
-		f := f
-
-		if f.dir != name {
-			continue
-		}
-
-		children = append(children, f)
+	dirs, ok := fsys.dirs[name]
+	if !ok {
+		return []fs.DirEntry{}, nil
 	}
 
-	slices.SortFunc(children, func(a, b fs.DirEntry) int {
-		return strings.Compare(a.Name(), b.Name())
-	})
-
-	return children, nil
+	return dirs, nil
 }
 
 type countReader struct {
@@ -259,20 +170,19 @@ func (cr *countReader) Read(p []byte) (int, error) {
 	return n, err
 }
 
-func New(open func() (io.ReadSeekCloser, error)) (*FS, error) {
+func New(ra io.ReaderAt, size int64) (*FS, error) {
 	fsys := &FS{
-		open:  open,
+		ra:    ra,
 		files: []*Entry{},
 		index: map[string]int{},
+		dirs:  map[string][]fs.DirEntry{},
 	}
+
+	// Number of entries in a given directory, so we know how large of a slice to allocate.
+	dirCount := map[string]int{}
 
 	// TODO: Consider caching this across builds.
-	r, err := open()
-	if err != nil {
-		return nil, err
-	}
-	defer r.Close()
-
+	r := io.NewSectionReader(ra, 0, size)
 	cr := &countReader{bufio.NewReaderSize(r, 1<<20), 0}
 	tr := tar.NewReader(cr)
 	for {
@@ -283,14 +193,45 @@ func New(open func() (io.ReadSeekCloser, error)) (*FS, error) {
 		if err != nil {
 			return nil, err
 		}
+		dir := path.Dir(hdr.Name)
 		fsys.index[hdr.Name] = len(fsys.files)
 		fsys.files = append(fsys.files, &Entry{
 			Header: *hdr,
 			Offset: cr.n,
-			dir:    path.Dir(hdr.Name),
+			dir:    dir,
 			fi:     hdr.FileInfo(),
 		})
+
+		dirCount[dir]++
+	}
+
+	// Pre-generate the results of ReadDir so we don't allocate a ton if fs.WalkDir calls us.
+	// TODO: Consider doing this lazily in a sync.Once the first time we see a ReadDir.
+	for dir, count := range dirCount {
+		fsys.dirs[dir] = make([]fs.DirEntry, 0, count)
+	}
+
+	for _, f := range fsys.files {
+		dirs := fsys.dirs[f.dir]
+		var de fs.DirEntry = f
+		pos, _ := slices.BinarySearchFunc(dirs, de, func(a, b fs.DirEntry) int {
+			return cmp.Compare(a.Name(), b.Name())
+		})
+		fsys.dirs[f.dir] = slices.Insert(dirs, pos, de)
 	}
 
 	return fsys, nil
+}
+
+func (fsys *FS) Close() error {
+	if fsys == nil {
+		return nil
+	}
+
+	closer, ok := fsys.ra.(io.Closer)
+	if !ok {
+		return nil
+	}
+
+	return closer.Close()
 }

--- a/pkg/apk/package.go
+++ b/pkg/apk/package.go
@@ -15,7 +15,6 @@
 package apk
 
 import (
-	"archive/tar"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -112,16 +111,12 @@ func ParsePackage(ctx context.Context, apkPackage io.Reader) (*Package, error) {
 
 	defer expanded.Close()
 
-	control, err := expanded.ControlData()
+	r, err := expanded.ControlFS.Open(".PKGINFO")
 	if err != nil {
 		return nil, fmt.Errorf("expanded.ControlData(): %v", err)
 	}
-	tarRead := tar.NewReader(control)
-	if _, err = tarRead.Next(); err != nil {
-		return nil, fmt.Errorf("tarRead.Next(): %v", err)
-	}
 
-	cfg, err := ini.ShadowLoad(tarRead)
+	cfg, err := ini.ShadowLoad(r)
 	if err != nil {
 		return nil, fmt.Errorf("ini.ShadowLoad(): %w", err)
 	}

--- a/pkg/apk/repo_test.go
+++ b/pkg/apk/repo_test.go
@@ -142,7 +142,7 @@ func TestGetRepositoryIndexes(t *testing.T) {
 		require.NoErrorf(t, err, "unable to get indexes")
 		require.Greater(t, len(indexes), 0, "no indexes found")
 
-		require.NoError(t, filepath.WalkDir(tmpDir, func(path string, d fs.DirEntry, err error) error {
+		require.NoError(t, filepath.WalkDir(tmpDir, func(path string, _ fs.DirEntry, _ error) error {
 			if filepath.Ext(path) == ".etag" {
 				t.Errorf("found etag file %q, expected none.", path)
 			}

--- a/pkg/fs/apkfs_test.go
+++ b/pkg/fs/apkfs_test.go
@@ -103,7 +103,7 @@ func TestReadAPKFile(t *testing.T) {
 		defer apkfs.Close()
 		// Find a specific file by walking the filesystem
 		found := false
-		err = fs.WalkDir(apkfs, ".", func(name string, d fs.DirEntry, err error) error {
+		err = fs.WalkDir(apkfs, ".", func(_ string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}

--- a/pkg/fs/memfs_test.go
+++ b/pkg/fs/memfs_test.go
@@ -436,7 +436,7 @@ func TestMemFSConsistentOrdering(t *testing.T) {
 	var results []string
 	for i := 0; i < 10; i++ {
 		var result []string
-		err := fs.WalkDir(m, "/", func(path string, d fs.DirEntry, err error) error {
+		err := fs.WalkDir(m, "/", func(path string, _ fs.DirEntry, err error) error {
 			require.NoError(t, err)
 			result = append(result, path)
 			return nil

--- a/pkg/fs/rwosfs_test.go
+++ b/pkg/fs/rwosfs_test.go
@@ -181,7 +181,7 @@ func TestDirFSConsistentOrdering(t *testing.T) {
 	var results []string
 	for i := 0; i < 10; i++ {
 		var result []string
-		err := fs.WalkDir(fsys, "/", func(path string, d fs.DirEntry, err error) error {
+		err := fs.WalkDir(fsys, "/", func(path string, _ fs.DirEntry, err error) error {
 			require.NoError(t, err)
 			result = append(result, path)
 			return nil


### PR DESCRIPTION
Previously this relied on an io.ReadSeekCloser opener. That style of access induced a syscall every time we opened a file, which ends up being pretty slow if we access a ton of files.

Now, this takes an already open io.ReaderAt, which means we only call open a single time.

Separately, tarfs will now pre-compute results for ReadDir. We used to iterate over every file and check to see if its parent matched the argument. Now, we just compute all the results up front with a much more efficient mechanism that pre-allocates everything and does a sorted insertion (instead of allocating and sorting in every ReadDir call).

Looking at a CPU profile of running "melange scan" on sqlpad...

```
     open(): 145ms ->  0ms
sca.Analyze: 275ms -> 20ms
  tarfs.New:  68ms -> 72ms
```

We pay a very small up-front cost in tarfs.New in exchange for much faster file access, especially for ReadDir.