### PR TITLE
apk: plumb more replaces_priority settings

### DIFF
--- a/pkg/apk/install_test.go
+++ b/pkg/apk/install_test.go
@@ -497,5 +497,8 @@ replaces = {{ $dep }}
 {{- if .ProviderPriority }}
 provider_priority = {{ .Dependencies.ProviderPriority }}
 {{- end }}
+{{- if .ReplacesPriority }}
+replaces_priority = {{ .Dependencies.ReplacesPriority }}
+{{- end }}
 datahash = {{.DataHash}}
 `

--- a/pkg/apk/installed.go
+++ b/pkg/apk/installed.go
@@ -314,6 +314,12 @@ func ParseInstalled(installed io.Reader) ([]*InstalledPackage, error) { //nolint
 				return nil, fmt.Errorf("cannot parse provider priority field %s: %w", val, err)
 			}
 			pkg.ProviderPriority = priority
+		case "q":
+			priority, err := strconv.ParseUint(val, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("cannot parse replaces priority field %s: %w", val, err)
+			}
+			pkg.ReplacesPriority = priority
 		case "C":
 			// Handle SHA1 checksums:
 			if strings.HasPrefix(val, "Q1") {

--- a/pkg/apk/package.go
+++ b/pkg/apk/package.go
@@ -47,6 +47,7 @@ func PackageToInstalled(pkg *Package) (out []string) {
 	out = append(out, fmt.Sprintf("S:%d", pkg.Size))
 	out = append(out, fmt.Sprintf("I:%d", pkg.InstalledSize))
 	out = append(out, fmt.Sprintf("k:%d", pkg.ProviderPriority))
+	out = append(out, fmt.Sprintf("q:%d", pkg.ReplacesPriority))
 	if len(pkg.Checksum) > 0 {
 		out = append(out, fmt.Sprintf("C:%s", pkg.ChecksumString()))
 	}
@@ -79,6 +80,7 @@ type Package struct {
 	Size             uint64 `ini:"size"`
 	InstalledSize    uint64
 	ProviderPriority uint64 `ini:"provider_priority"`
+	ReplacesPriority uint64 `ini:"replaces_priority"`
 	BuildTime        time.Time
 	BuildDate        int64    `ini:"builddate"`
 	RepoCommit       string   `ini:"commit"`


### PR DESCRIPTION
replaces_priority exists in the PKGINFO and installed database, but not APKINDEX it seems.

I've added things blindly..... and not sure there are any tests for these things. Any suggestions on how to add tests for these things for both provider_priority and replaces_priority are welcomed.