### PR TITLE
Apk allows to install multiple packages with same provides

### DIFF
--- a/pkg/apk/repo.go
+++ b/pkg/apk/repo.go
@@ -327,6 +327,10 @@ func (p *PkgResolver) disqualifyConflicts(pkg *RepositoryPackage, dq map[*Reposi
 				continue
 			}
 
+			if pkg.ProviderPriority > conflict.ProviderPriority {
+				continue
+			}
+
 			p.disqualify(dq, conflict.RepositoryPackage, pkg.Filename()+" already provides "+name)
 		}
 	}


### PR DESCRIPTION
As long as their provider priorities are straight.

I am very skeptical if this is deterministic, or just lucky.