### PR TITLE
Only allow overlapping virtual providers

### DIFF
--- a/pkg/apk/repo.go
+++ b/pkg/apk/repo.go
@@ -309,6 +309,14 @@ func (p *PkgResolver) disqualifyProviders(constraint string, dq map[*RepositoryP
 }
 
 func (p *PkgResolver) conflictingVersion(constraint parsedConstraint, conflict *repositoryPackage) bool {
+	// If the constraint is not a virtual, everything will conflict with it.
+	// TODO: Figure out if this logic is actually equivalent to how apk disqualifies virtual.
+	if constraint.version != "" {
+		return true
+	}
+
+	// From here on, "the same version" really means it's a virtual, but let's keep the diff small until we revisit.
+
 	if conflict.Name == constraint.name {
 		return conflict.Version != constraint.version
 	}


### PR DESCRIPTION
After more testing, we found that apk will only allow two things that provide the same virtual if there are no versions, not if the versions are the same, so we adjust that logic a bit to be consistent.