### PR TITLE
support HTTP basic auth

### DIFF
--- a/pkg/apk/index.go
+++ b/pkg/apk/index.go
@@ -173,7 +173,7 @@ func shouldCheckSignatureForIndex(index string, arch string, opts *indexOpts) bo
 	return true
 }
 
-func getRepositoryIndex(ctx context.Context, u string, keys map[string][]byte, arch string, opts *indexOpts) (*APKIndex, error) {
+func getRepositoryIndex(ctx context.Context, u string, keys map[string][]byte, arch string, opts *indexOpts) (*APKIndex, error) { //nolint:gocyclo
 	// Normalize the repo as a URI, so that local paths
 	// are translated into file:// URLs, allowing them to be parsed
 	// into a url.URL{}.

--- a/pkg/apk/options.go
+++ b/pkg/apk/options.go
@@ -30,6 +30,7 @@ type opts struct {
 	version            string
 	cache              *cache
 	noSignatureIndexes []string
+	user, pass         string
 }
 
 type Option func(*opts) error
@@ -101,6 +102,14 @@ func WithCache(cacheDir string, offline bool) Option {
 func WithNoSignatureIndexes(noSignatureIndex ...string) Option {
 	return func(o *opts) error {
 		o.noSignatureIndexes = append(o.noSignatureIndexes, noSignatureIndex...)
+		return nil
+	}
+}
+
+func WithAuth(user, pass string) Option {
+	return func(o *opts) error {
+		o.user = user
+		o.pass = pass
 		return nil
 	}
 }

--- a/pkg/apk/repo_test.go
+++ b/pkg/apk/repo_test.go
@@ -334,7 +334,6 @@ func TestGetRepositoryIndexes(t *testing.T) {
 			require.NoErrorf(t, err, "unable to get indexes")
 		})
 	})
-
 }
 
 func testGetPackagesAndIndex() ([]*RepositoryPackage, []*RepositoryWithIndex) {


### PR DESCRIPTION
This adds `WithAuth(user, pass)` and `WithIndexAuth(user, pass)` for `FetchPackages` and `GetRepositoryIndexes`, respectively. These are passed in HTTP requests to the server using `req.SetBasicAuth(user, pass)`.

Tests for this use `httptest`, which required allowing `http://` URLs in some places (I hope I got them all 🤞), which I think is safe enough in general since things should also check signatures.

Now that we have this, we can plumb `httptest` into more places in tests, instead of making real HTTP requests to Alpine. 🤞 