### PR TITLE
Clone the HTTP request for the HEAD.

### DIFF
--- a/pkg/apk/cache.go
+++ b/pkg/apk/cache.go
@@ -54,7 +54,9 @@ func (e *etagCache) get(t *cacheTransport, request *http.Request, cacheFile stri
 	// Do all the expensive things inside the once.
 	once, _ := e.etags.LoadOrStore(url, &sync.Once{})
 	once.(*sync.Once).Do(func() {
-		resp, rerr := t.wrapped.Head(url)
+		req := request.Clone(request.Context())
+		req.Method = http.MethodHead
+		resp, rerr := t.wrapped.Do(req)
 		if resp != nil {
 			// We don't expect any body from a HEAD so just always close it to appease the linter.
 			resp.Body.Close()


### PR DESCRIPTION
In the APK cache logic, instead of simply calling `Head(url)` which ignores any authentication set on the request, this change clones the request and changes the method to HEAD.