### PR TITLE
enable per-host auth

### DIFF
--- a/pkg/apk/implementation.go
+++ b/pkg/apk/implementation.go
@@ -65,7 +65,7 @@ type APK struct {
 	cache              *cache
 	ignoreSignatures   bool
 	noSignatureIndexes []string
-	user, pass         string
+	auth               map[string]auth
 
 	// filename to owning package, last write wins
 	installedFiles map[string]*Package
@@ -94,8 +94,7 @@ func New(options ...Option) (*APK, error) {
 		cache:              opt.cache,
 		noSignatureIndexes: opt.noSignatureIndexes,
 		installedFiles:     map[string]*Package{},
-		user:               opt.user,
-		pass:               opt.pass,
+		auth:               opt.auth,
 	}, nil
 }
 
@@ -414,7 +413,7 @@ func (a *APK) InitKeyring(ctx context.Context, keyFiles, extraKeyFiles []string)
 					pass, _ := asURL.User.Password()
 					req.SetBasicAuth(user, pass)
 					req.URL.User = nil
-				} else if a.user != "" && a.pass != "" {
+				} else if a, ok := a.auth[asURL.Host]; ok && a.user != "" && a.pass != "" {
 					req.SetBasicAuth(a.user, a.pass)
 				}
 
@@ -1053,7 +1052,7 @@ func (a *APK) FetchPackage(ctx context.Context, pkg InstallablePackage) (io.Read
 		if err != nil {
 			return nil, err
 		}
-		if a.user != "" && a.pass != "" {
+		if a, ok := a.auth[asURL.Host]; ok && a.user != "" && a.pass != "" {
 			req.SetBasicAuth(a.user, a.pass)
 		}
 

--- a/pkg/apk/implementation_test.go
+++ b/pkg/apk/implementation_test.go
@@ -238,6 +238,7 @@ func TestInitKeyring(t *testing.T) {
 			http.FileServer(http.Dir(testPrimaryPkgDir)).ServeHTTP(w, r)
 		}))
 		defer s.Close()
+		host := strings.TrimPrefix(s.URL, "http://")
 
 		ctx := context.Background()
 
@@ -246,7 +247,7 @@ func TestInitKeyring(t *testing.T) {
 			err := src.MkdirAll("lib/apk/db", 0o755)
 			require.NoError(t, err, "unable to mkdir /lib/apk/db")
 
-			a, err := New(WithFS(src), WithAuth(testUser, testPass))
+			a, err := New(WithFS(src), WithAuth(host, testUser, testPass))
 			require.NoError(t, err, "unable to create APK")
 			err = a.InitDB(ctx)
 			require.NoError(t, err)
@@ -261,7 +262,7 @@ func TestInitKeyring(t *testing.T) {
 			err := src.MkdirAll("lib/apk/db", 0o755)
 			require.NoError(t, err, "unable to mkdir /lib/apk/db")
 
-			a, err := New(WithFS(src), WithAuth("baduser", "badpass"))
+			a, err := New(WithFS(src), WithAuth(host, "baduser", "badpass"))
 			require.NoError(t, err, "unable to create APK")
 			err = a.InitDB(ctx)
 			require.NoError(t, err)
@@ -544,6 +545,7 @@ func TestAuth_good(t *testing.T) {
 		http.FileServer(http.Dir(testPrimaryPkgDir)).ServeHTTP(w, r)
 	}))
 	defer s.Close()
+	host := strings.TrimPrefix(s.URL, "http://")
 
 	repo := Repository{URI: s.URL}
 	repoWithIndex := repo.WithIndex(&APKIndex{Packages: []*Package{&testPkg}})
@@ -554,7 +556,7 @@ func TestAuth_good(t *testing.T) {
 	err := src.MkdirAll("lib/apk/db", 0o755)
 	require.NoError(t, err, "unable to mkdir /lib/apk/db")
 
-	a, err := New(WithFS(src), WithAuth(testUser, testPass))
+	a, err := New(WithFS(src), WithAuth(host, testUser, testPass))
 	require.NoError(t, err, "unable to create APK")
 	err = a.InitDB(ctx)
 	require.NoError(t, err)
@@ -575,6 +577,7 @@ func TestAuth_bad(t *testing.T) {
 		http.FileServer(http.Dir(testPrimaryPkgDir)).ServeHTTP(w, r)
 	}))
 	defer s.Close()
+	host := strings.TrimPrefix(s.URL, "http://")
 
 	repo := Repository{URI: s.URL}
 	repoWithIndex := repo.WithIndex(&APKIndex{Packages: []*Package{&testPkg}})
@@ -585,7 +588,7 @@ func TestAuth_bad(t *testing.T) {
 	err := src.MkdirAll("lib/apk/db", 0o755)
 	require.NoError(t, err, "unable to mkdir /lib/apk/db")
 
-	a, err := New(WithFS(src), WithAuth("baduser", "badpass"))
+	a, err := New(WithFS(src), WithAuth(host, "baduser", "badpass"))
 	require.NoError(t, err, "unable to create APK")
 	err = a.InitDB(ctx)
 	require.NoError(t, err)

--- a/pkg/apk/options.go
+++ b/pkg/apk/options.go
@@ -30,7 +30,7 @@ type opts struct {
 	version            string
 	cache              *cache
 	noSignatureIndexes []string
-	user, pass         string
+	auth               map[string]auth
 }
 
 type Option func(*opts) error
@@ -106,10 +106,14 @@ func WithNoSignatureIndexes(noSignatureIndex ...string) Option {
 	}
 }
 
-func WithAuth(user, pass string) Option {
+type auth struct{ user, pass string }
+
+func WithAuth(domain, user, pass string) Option {
 	return func(o *opts) error {
-		o.user = user
-		o.pass = pass
+		if o.auth == nil {
+			o.auth = make(map[string]auth)
+		}
+		o.auth[domain] = auth{user, pass}
 		return nil
 	}
 }

--- a/pkg/apk/repo.go
+++ b/pkg/apk/repo.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"path/filepath"
 	"strings"
 
@@ -176,11 +177,14 @@ func (a *APK) GetRepositoryIndexes(ctx context.Context, ignoreSignatures bool) (
 	if a.cache != nil {
 		httpClient = a.cache.client(httpClient, true)
 	}
-	return GetRepositoryIndexes(ctx, repos, keys, arch,
-		WithIgnoreSignatures(ignoreSignatures),
+	opts := []IndexOption{WithIgnoreSignatures(ignoreSignatures),
 		WithIgnoreSignatureForIndexes(a.noSignatureIndexes...),
-		WithHTTPClient(httpClient),
-		WithIndexAuth(a.user, a.pass))
+		WithHTTPClient(httpClient)}
+	for domain, auth := range a.auth {
+		log.Println("forwarding auth for ", domain)
+		opts = append(opts, WithIndexAuth(domain, auth.user, auth.pass))
+	}
+	return GetRepositoryIndexes(ctx, repos, keys, arch, opts...)
 }
 
 // PkgResolver resolves packages from a list of indexes.

--- a/pkg/apk/repo.go
+++ b/pkg/apk/repo.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"path/filepath"
 	"strings"
 
@@ -181,7 +180,6 @@ func (a *APK) GetRepositoryIndexes(ctx context.Context, ignoreSignatures bool) (
 		WithIgnoreSignatureForIndexes(a.noSignatureIndexes...),
 		WithHTTPClient(httpClient)}
 	for domain, auth := range a.auth {
-		log.Println("forwarding auth for ", domain)
 		opts = append(opts, WithIndexAuth(domain, auth.user, auth.pass))
 	}
 	return GetRepositoryIndexes(ctx, repos, keys, arch, opts...)

--- a/pkg/apk/repo_test.go
+++ b/pkg/apk/repo_test.go
@@ -315,11 +315,12 @@ func TestIndexAuth_good(t *testing.T) {
 		http.FileServer(http.Dir(testPrimaryPkgDir)).ServeHTTP(w, r)
 	}))
 	defer s.Close()
+	host := strings.TrimPrefix(s.URL, "http://")
 
 	ctx := context.Background()
 
 	a, err := New(WithFS(apkfs.NewMemFS()),
-		WithAuth(testUser, testPass),
+		WithAuth(host, testUser, testPass),
 		WithArch("x86_64"))
 	require.NoErrorf(t, err, "unable to create APK")
 	err = a.InitDB(ctx)
@@ -343,11 +344,12 @@ func TestIndexAuth_bad(t *testing.T) {
 		http.FileServer(http.Dir(testPrimaryPkgDir)).ServeHTTP(w, r)
 	}))
 	defer s.Close()
+	host := strings.TrimPrefix(s.URL, "http://")
 
 	ctx := context.Background()
 
 	a, err := New(WithFS(apkfs.NewMemFS()),
-		WithAuth("baduser", "badpass"),
+		WithAuth(host, "baduser", "badpass"),
 		WithArch("x86_64"))
 	require.NoErrorf(t, err, "unable to create APK")
 	err = a.InitDB(ctx)


### PR DESCRIPTION
This enables a single go-apk to read from two repositories, one which may allow specifying auth and others which might not (`packages.wolfi.dev`, backed by GCS). To enable this the caller would have to specify the domain they want to send auth to.